### PR TITLE
Improvements to mention ticket command

### DIFF
--- a/settings-template.jsonc
+++ b/settings-template.jsonc
@@ -21,6 +21,19 @@
 	// The message ID of the bot's roles message
 	"roles_message": "<Roles message ID>",
 
+	// Whether the bot should send an embed when a full URL to a ticket gets posted
+	"ticketUrlsCauseEmbed": false,
+
+	// A prefix that prevents the bot from posting an embed for a mentioned ticket.
+	// If this prefix is longer than 1, none of the characters can be used.
+	// When omitted or empty, no prefix prevents embeds.
+	"forbiddenTicketPrefix": "<Prefix>",
+
+	// Prefix that needs to preceed any mentioned ticket in order for the bot to post an embed
+	// If this prefix is longer than 1, the entire string needs to prefix any mentioned ticket.
+	// When omitted or empty, no prefix is required for posting embeds.
+	"requiredTicketPrefix": "<Prefix>",
+
 	// The channel IDs of the bot's request channels
 	"request_channels": ["<Channel 1 ID>", "<Channel 2 ID>"],
 

--- a/settings-template.jsonc
+++ b/settings-template.jsonc
@@ -21,7 +21,8 @@
 	// The message ID of the bot's roles message
 	"roles_message": "<Roles message ID>",
 
-	// Whether the bot should send an embed when a full URL to a ticket gets posted
+	// Whether the bot should send an embed when a full URL to a ticket gets posted.
+	// Optional, false by default
 	"ticketUrlsCauseEmbed": false,
 
 	// A prefix that prevents the bot from posting an embed for a mentioned ticket.

--- a/src/BotConfig.ts
+++ b/src/BotConfig.ts
@@ -27,7 +27,7 @@ export default class BotConfig {
 	public static rolesMessage: string;
 	public static requestChannels: string[];
 
-	//settings for mention command
+	// settings for mention command
 	public static ticketUrlsCauseEmbed: boolean;
 	public static requiredTicketPrefix: string;
 	public static forbiddenTicketPrefix: string;
@@ -68,8 +68,7 @@ export default class BotConfig {
 		if ( !settings.request_channels ) throw 'Request channels are not set';
 		this.requestChannels = settings.request_channels;
 
-		//no check, beacause it's a boolean.
-		this.ticketUrlsCauseEmbed = settings.ticketUrlsCauseEmbed;
+		this.ticketUrlsCauseEmbed = !!settings.ticketUrlsCauseEmbed;
 
 		if ( !settings.forbiddenTicketPrefix ) this.forbiddenTicketPrefix = '';
 		else this.forbiddenTicketPrefix = settings.forbiddenTicketPrefix;

--- a/src/BotConfig.ts
+++ b/src/BotConfig.ts
@@ -27,6 +27,11 @@ export default class BotConfig {
 	public static rolesMessage: string;
 	public static requestChannels: string[];
 
+	//settings for mention command
+	public static ticketUrlsCauseEmbed: boolean;
+	public static requiredTicketPrefix: string;
+	public static forbiddenTicketPrefix: string;
+
 	public static projects: Array<string>;
 
 	public static roles: RoleConfig[];
@@ -62,6 +67,15 @@ export default class BotConfig {
 
 		if ( !settings.request_channels ) throw 'Request channels are not set';
 		this.requestChannels = settings.request_channels;
+
+		//no check, beacause it's a boolean.
+		this.ticketUrlsCauseEmbed = settings.ticketUrlsCauseEmbed;
+
+		if ( !settings.forbiddenTicketPrefix ) this.forbiddenTicketPrefix = '';
+		else this.forbiddenTicketPrefix = settings.forbiddenTicketPrefix;
+
+		if ( !settings.requiredTicketPrefix ) this.requiredTicketPrefix = '';
+		else this.requiredTicketPrefix = settings.requiredTicketPrefix;
 
 		if ( !settings.projects ) throw 'Projects are not set';
 		this.projects = settings.projects;

--- a/src/commands/MentionCommand.ts
+++ b/src/commands/MentionCommand.ts
@@ -5,7 +5,11 @@ import BotConfig from '../BotConfig';
 
 export default class MentionCommand extends Command {
 	public test( messageText: string ): boolean | string[] {
-		const ticketRegex = RegExp( `(?:^|[^!])((?:${ BotConfig.projects.join( '|' ) })-\\d+)`, 'g' );
+		const ticketPattern = `(?:${ BotConfig.projects.join( '|' ) })-\\d+`;
+		const ticketRegex = RegExp( `(?:^|[^!])(${ticketPattern})`, 'g' );
+
+		//remove all issues posted in the form of a link from the search
+		messageText = messageText.replace(new RegExp(`https?://bugs.mojang.com/browse/${ticketPattern}`, 'g'), '');
 
 		let ticketMatch: RegExpExecArray;
 		const ticketMatches: Set<string> = new Set();


### PR DESCRIPTION
This pr includes some previously discussed changes to the mention command.

- It is now configurable whether links should trigger the bot.
- In case links trigger the bot, and a message containing only an issue link gets sent, this message is auto-deleted like usually
- It is now configurable if and which prefix is required to trigger the mention command.
- It is now configurable if and which prefixes prevent the mention command from triggering.