### PR TITLE
Fix #9

### DIFF
--- a/src/permissions/ModeratorPermission.ts
+++ b/src/permissions/ModeratorPermission.ts
@@ -6,7 +6,7 @@ import Permission from './Permission';
  * This allows the command to be run by any guild member who has the "Manage messages" permission serverwide.
  */
 export default class ModeratorPermission extends Permission {
-	public checkPermission( member: GuildMember ): boolean {
-		return member.hasPermission( 'MANAGE_MESSAGES' );
+	public checkPermission( member?: GuildMember ): boolean {
+		return member?.hasPermission( 'MANAGE_MESSAGES' );
 	}
 }

--- a/src/permissions/OwnerPermission.ts
+++ b/src/permissions/OwnerPermission.ts
@@ -3,7 +3,7 @@ import Permission from './Permission';
 import BotConfig from '../BotConfig';
 
 export default class OwnerPermission extends Permission {
-	public checkPermission( member: GuildMember ): boolean {
-		return member.id === BotConfig.owner;
+	public checkPermission( member?: GuildMember ): boolean {
+		return member?.id === BotConfig.owner;
 	}
 }


### PR DESCRIPTION
This tries to mitigate the reason for #9, in theory it seems like it happens whenever a member leaves the server before the command is processed.

I'm not really sure if that would be the only case in which this happens though, as it seems quite unlikely that this triggered the error from what I can tell. Perhaps there's something I missed?

Anyway, with this change, the permission check for moderator and owner should now always fail (and not throw an error) in case `member` is `undefined` or `null`.