### PR TITLE
Add Mention Config. Implements #14, #15 and #20

### DIFF
--- a/settings-template.jsonc
+++ b/settings-template.jsonc
@@ -25,37 +25,37 @@
 	"embed_types": {
 		"<name of an embed type>": {
 
-			// Whether to include the embed title
+			// Optional. Whether to include the embed title
 			// Default: false
-			"title": "<bool>",
+			"title": false,
 
-			// Settings for the description. Either below's object or false for no description.
+			// Optional. Settings for the description. Either below's object or false for no description.
 			// Default: false
 			"description": {
 				// If set, the description cannot be longer than n characters.
-				"max_characters": "<num>",
+				"max_characters": 1234,
 				// If set, the description cannot include more than n line breaks.
-				"max_line_breaks": 3,
+				"max_line_breaks": 2,
 				// If set, everything from the description that matches any of the given regex strings will be stripped.
 				"exclude": [ "<a regex string>" ]
 			},
 
-			// Whether the author should be included.
+			// Optional. Whether the author should be included.
 			// Default: false
-			"author": "<bool>",
+			"author": false,
 			
-			// Whether the embed should link to the ticket included.
+			// Optional. Whether the embed should link to the ticket included.
 			// Default: false
-			"url": "<bool>",
+			"url": false,
 			
-			// Whether the embed should include the first image attachment as Image.
+			// Optional. Whether the embed should include the first image attachment as Image.
 			// Default: false
-			"thumbnail": "<bool>",
+			"thumbnail": false,
 
 			// The color the embed should have
 			"color": "DiscordColorResolvable",
 
-			// A list of additional fields that should be added. Can be set to false for no fields.
+			// Optional. A list of additional fields that should be added. Can be set to false for no fields.
 			// Default: false
 			"fields": [
 				{
@@ -71,46 +71,48 @@
 					// Not needed for status, large_status and duplicate_count
 					"path": "<path-to-field>",
 
-					// Whether the field should be inline. A maximum of 3 fields will appear next to each other when set.
+					// Optional. Whether the field should be inline. A maximum of 3 fields will appear next to each other when set.
 					// Default: true
-					"inline": "<bool>",
+					"inline": false,
 
-					// Currently only for joined_array.
+					// Optional. Currently only for joined_array.
 					// Path for object in the array that should be used for display.
 					// Default: Print entire object. 
 					"inner_path": "<inner path>"
 				}
+				// ... You can add more fields here
 			]
 		}
+		// ... You can define moore embed types here
 	},
 
 	// Rules for invoking different embeds when mentioning a ticket.
 	// In case multiple types match, the one defined first will be used.
 	"mention_types": [
 		{
-			// If set to true, this mention type will only trigger if the mentioned ticket was provided as URL.
+			// Optional. If set to true, this mention type will only trigger if the mentioned ticket was provided as URL.
 			// Default: false
-			"require_url": "<bool>",
+			"require_url": false,
 
-			// If set to true, this mention type will not trigger if the mentioned ticket was provided as URL.
+			// Optional. If set to true, this mention type will not trigger if the mentioned ticket was provided as URL.
 			// Default: false
-			"forbid_url": "<bool>",
+			"forbid_url": false,
 
-			// If set, this mention type will only trigger if the mentioned ticket was prefixed with the given string.
+			// Optional. If set, this mention type will only trigger if the mentioned ticket was prefixed with the given string.
 			// This will be ignored if require_url is set to true.
 			// Default: no required prefix.
 			"required_prefix": "<prefix>",
 
-			// If set, this mention type will not trigger if the mentioned ticket was prefixed with one of the given characters.
+			// Optional. If set, this mention type will not trigger if the mentioned ticket was prefixed with one of the given characters.
 			// This will be ignored if require_url is set to true.
 			// Default: no forbidden prefix.
 			"forbidden_prefix": "<prefix>",
 
-			// If set, this mention type will only trigger if the message includes a keyword somewhere in the message.
+			// Optional. If set, this mention type will only trigger if the message includes a keyword somewhere in the message.
 			// Default: no required keyword.
 			"required_keyword": "<keyword>",
 
-			// If set, this mention type will not trigger if the message includes a keyword somewhere in the message.
+			// Optional. If set, this mention type will not trigger if the message includes a keyword somewhere in the message.
 			// Default: no forbidden keyword.
 			"forbidden_keyword": "<keyword>",
 
@@ -118,16 +120,17 @@
 			// This embed will be used to display the mention.
 			"embed": "<embed name>"
 		}
+		// ... You can add more mention types here
 	],
 
 	// Number of ungrouped mentions that will produce an individual embed.
 	// If this number is exceeded, a single embed including all ticket keys and summaries will be generated instead.
 	// Default: no limit.
-	"max_ungrouped_mentions": "<num>",
+	"max_ungrouped_mentions": 1,
 
 	// Maximum number of mentions that will appear in a grouped embed (see max_ungrouped_mentions).
 	// If this number is exceeded, a jira search query link will be provided at the end, allowing to view a list of all tickets on jira.
-	"max_grouped_mentions": "<num>",
+	"max_grouped_mentions": 10,
 
 	// The channel IDs of the bot's request channels
 	"request_channels": ["<Channel 1 ID>", "<Channel 2 ID>"],
@@ -166,7 +169,21 @@
 			"title": "{{num}} tickets blabla in the last 15 minutes!",
 			
 			// Optional. The message accompanying this feed embed, in case there's only one ticket. If this is not set, `title` will be used instead.
-			"title_single": "One ticket blabla in the last 15 minutes!"
+			"title_single": "One ticket blabla in the last 15 minutes!",
+
+			// An embed name defined in embed_types.
+			// This embed will be used to display issues from the feed.
+			"embed": "<embed name>",
+
+			// Optional. Number of ungrouped mentions that will produce an individual embed for this feed.
+			// If this number is exceeded, a single embed including all ticket keys and summaries will be generated instead.
+			// Default: Same as max_ungrouped_mentions from root.
+			"max_ungrouped_mentions": 1,
+
+			// Optional. Maximum number of mentions that will appear in a grouped embed (see max_ungrouped_mentions).
+			// If this number is exceeded, a jira search query link will be provided at the end, allowing to view a list of all tickets on jira.
+			// Default: Same as max_grouped_mentions from root.
+			"max_grouped_mentions": 10
 		}
 		// ... you can add more feeds here
 	]

--- a/settings-template.jsonc
+++ b/settings-template.jsonc
@@ -21,19 +21,113 @@
 	// The message ID of the bot's roles message
 	"roles_message": "<Roles message ID>",
 
-	// Whether the bot should send an embed when a full URL to a ticket gets posted.
-	// Optional, false by default
-	"ticketUrlsCauseEmbed": false,
+	// Map of custom embed types
+	"embed_types": {
+		"<name of an embed type>": {
 
-	// A prefix that prevents the bot from posting an embed for a mentioned ticket.
-	// If this prefix is longer than 1, none of the characters can be used.
-	// When omitted or empty, no prefix prevents embeds.
-	"forbiddenTicketPrefix": "<Prefix>",
+			// Whether to include the embed title
+			// Default: false
+			"title": "<bool>",
 
-	// Prefix that needs to preceed any mentioned ticket in order for the bot to post an embed
-	// If this prefix is longer than 1, the entire string needs to prefix any mentioned ticket.
-	// When omitted or empty, no prefix is required for posting embeds.
-	"requiredTicketPrefix": "<Prefix>",
+			// Settings for the description. Either below's object or false for no description.
+			// Default: false
+			"description": {
+				// If set, the description cannot be longer than n characters.
+				"max_characters": "<num>",
+				// If set, the description cannot include more than n line breaks.
+				"max_line_breaks": 3,
+				// If set, everything from the description that matches any of the given regex strings will be stripped.
+				"exclude": [ "<a regex string>" ]
+			},
+
+			// Whether the author should be included.
+			// Default: false
+			"author": "<bool>",
+			
+			// Whether the embed should link to the ticket included.
+			// Default: false
+			"url": "<bool>",
+			
+			// Whether the embed should include the first image attachment as Image.
+			// Default: false
+			"thumbnail": "<bool>",
+
+			// The color the embed should have
+			"color": "DiscordColorResolvable",
+
+			// A list of additional fields that should be added. Can be set to false for no fields.
+			// Default: false
+			"fields": [
+				{
+					// Type of the field.
+					// Currently available: status, large_status, field, user, joined_array, array_count, duplicate_count, date, from_now
+					"type": "<type>",
+
+					// Label the field should appear with.
+					"label": "<label>",
+
+					// Path to the field in the jira json response. See jira api documentaion for more details.
+					// Path members are seperated with dots (.) And the path starts at ticketResponse.fields
+					// Not needed for status, large_status and duplicate_count
+					"path": "<path-to-field>",
+
+					// Whether the field should be inline. A maximum of 3 fields will appear next to each other when set.
+					// Default: true
+					"inline": "<bool>",
+
+					// Currently only for joined_array.
+					// Path for object in the array that should be used for display.
+					// Default: Print entire object. 
+					"inner_path": "<inner path>"
+				}
+			]
+		}
+	},
+
+	// Rules for invoking different embeds when mentioning a ticket.
+	// In case multiple types match, the one defined first will be used.
+	"mention_types": [
+		{
+			// If set to true, this mention type will only trigger if the mentioned ticket was provided as URL.
+			// Default: false
+			"require_url": "<bool>",
+
+			// If set to true, this mention type will not trigger if the mentioned ticket was provided as URL.
+			// Default: false
+			"forbid_url": "<bool>",
+
+			// If set, this mention type will only trigger if the mentioned ticket was prefixed with the given string.
+			// This will be ignored if require_url is set to true.
+			// Default: no required prefix.
+			"required_prefix": "<prefix>",
+
+			// If set, this mention type will not trigger if the mentioned ticket was prefixed with one of the given characters.
+			// This will be ignored if require_url is set to true.
+			// Default: no forbidden prefix.
+			"forbidden_prefix": "<prefix>",
+
+			// If set, this mention type will only trigger if the message includes a keyword somewhere in the message.
+			// Default: no required keyword.
+			"required_keyword": "<keyword>",
+
+			// If set, this mention type will not trigger if the message includes a keyword somewhere in the message.
+			// Default: no forbidden keyword.
+			"forbidden_keyword": "<keyword>",
+
+			// An embed name defined in embed_types.
+			// This embed will be used to display the mention.
+			"embed": "<embed name>"
+		}
+	],
+
+	// Number of ungrouped mentions that will produce an individual embed.
+	// If this number is exceeded, a single embed including all ticket keys and summaries will be generated instead.
+	// Default: no limit.
+	"max_ungrouped_mentions": "<num>",
+
+	// Maximum number of mentions that will appear in a grouped embed (see max_ungrouped_mentions).
+	// If this number is exceeded, a jira search query link will be provided at the end, allowing to view a list of all tickets on jira.
+	"max_grouped_mentions": "<num>",
 
 	// The channel IDs of the bot's request channels
 	"request_channels": ["<Channel 1 ID>", "<Channel 2 ID>"],

--- a/settings-template.jsonc
+++ b/settings-template.jsonc
@@ -125,7 +125,7 @@
 
 	// Number of ungrouped mentions that will produce an individual embed.
 	// If this number is exceeded, a single embed including all ticket keys and summaries will be generated instead.
-	// Default: no limit.
+	// A number smaller than 1 means no limit.
 	"max_ungrouped_mentions": 1,
 
 	// Maximum number of mentions that will appear in a grouped embed (see max_ungrouped_mentions).
@@ -177,6 +177,7 @@
 
 			// Optional. Number of ungrouped mentions that will produce an individual embed for this feed.
 			// If this number is exceeded, a single embed including all ticket keys and summaries will be generated instead.
+			// A number smaller than 1 means no limit.
 			// Default: Same as max_ungrouped_mentions from root.
 			"max_ungrouped_mentions": 1,
 

--- a/src/BotConfig.ts
+++ b/src/BotConfig.ts
@@ -1,5 +1,6 @@
 import { Client } from 'discord.js';
 import MojiraBot from './MojiraBot';
+import MentionConfig, { EmbedConfig } from './MentionConfig';
 
 export interface RoleConfig {
 	emoji: string;
@@ -27,10 +28,10 @@ export default class BotConfig {
 	public static rolesMessage: string;
 	public static requestChannels: string[];
 
-	// settings for mention command
-	public static ticketUrlsCauseEmbed: boolean;
-	public static requiredTicketPrefix: string;
-	public static forbiddenTicketPrefix: string;
+	private static embedTypes: Map<string, EmbedConfig>;
+	public static mentionTypes: MentionConfig[];
+	public static maxUngroupedMentions?: number;
+	public static maxGroupedMentions?: number;
 
 	public static projects: Array<string>;
 
@@ -68,13 +69,23 @@ export default class BotConfig {
 		if ( !settings.request_channels ) throw 'Request channels are not set';
 		this.requestChannels = settings.request_channels;
 
-		this.ticketUrlsCauseEmbed = !!settings.ticketUrlsCauseEmbed;
+		if ( !settings.embed_types ) throw 'Embed Types are not defined!';
+		this.embedTypes = new Map<string, EmbedConfig>();
+		Object.keys( settings.embed_types ).forEach( ( key: string ) => {
+			this.embedTypes.set( key, new EmbedConfig( settings.embed_types[key] ) );
+		} );
 
-		if ( !settings.forbiddenTicketPrefix ) this.forbiddenTicketPrefix = '';
-		else this.forbiddenTicketPrefix = settings.forbiddenTicketPrefix;
+		if ( !( settings.mention_types instanceof Array ) ) throw 'Mention Types are not defined!';
+		this.mentionTypes = new Array<MentionConfig>();
 
-		if ( !settings.requiredTicketPrefix ) this.requiredTicketPrefix = '';
-		else this.requiredTicketPrefix = settings.requiredTicketPrefix;
+		for ( const mentionType of settings.mention_types ) {
+			this.mentionTypes.push( new MentionConfig( mentionType, this.embedTypes ) );
+		}
+
+		this.maxUngroupedMentions = settings.max_ungrouped_mentions as number;
+
+		if( settings.max_grouped_mentions === undefined ) throw 'Max grouped mentions are not defined!';
+		this.maxGroupedMentions = settings.max_grouped_mentions as number;
 
 		if ( !settings.projects ) throw 'Projects are not set';
 		this.projects = settings.projects;

--- a/src/BotConfig.ts
+++ b/src/BotConfig.ts
@@ -12,7 +12,10 @@ export interface FilterFeedConfig {
 	jql: string;
 	channel: string;
 	title: string;
-	title_single?: string;
+	embed: EmbedConfig;
+	maxUngroupedMentions?: number;
+	maxGroupedMentions?: number;
+	titleSingle?: string;
 }
 
 export default class BotConfig {
@@ -97,7 +100,23 @@ export default class BotConfig {
 		this.filterFeedInterval = settings.filter_feed_interval;
 
 		if ( !settings.filter_feeds ) throw 'Filter feeds are not set';
-		this.filterFeeds = settings.filter_feeds;
+		this.filterFeeds = new Array<FilterFeedConfig>();
+
+		for( const filterFeed of settings.filter_feeds ) {
+			if( !filterFeed.embed ) throw 'A filter feed has no embed.';
+			const feed = {};
+
+			Object.keys( filterFeed ).forEach( key => {
+				const camelCaseKey = key.replace( /_./g, match => match.substring( 1, 2 ).toUpperCase() );
+				feed[ camelCaseKey ] = filterFeed[ key ];
+
+			} );
+
+			feed[ 'embed' ] = this.embedTypes.get( filterFeed.embed );
+			if( !feed[ 'embed' ] ) throw `A filter feed has an undefined embed: ${ filterFeed.embed }`;
+
+			this.filterFeeds.push( feed as FilterFeedConfig );
+		}
 	}
 
 	public static async login( client: Client ): Promise<boolean> {

--- a/src/BotConfig.ts
+++ b/src/BotConfig.ts
@@ -85,6 +85,7 @@ export default class BotConfig {
 			this.mentionTypes.push( new MentionConfig( mentionType, this.embedTypes ) );
 		}
 
+		if( settings.max_grouped_mentions === undefined ) throw 'Max ungrouped mentions are not defined!';
 		this.maxUngroupedMentions = settings.max_ungrouped_mentions as number;
 
 		if( settings.max_grouped_mentions === undefined ) throw 'Max grouped mentions are not defined!';

--- a/src/MentionConfig.ts
+++ b/src/MentionConfig.ts
@@ -1,0 +1,110 @@
+import { ColorResolvable } from 'discord.js';
+
+export interface FieldConfig {
+	type: FieldType;
+	label: string;
+	path?: string;
+	inline?: boolean;
+	innerPath?: string;
+}
+
+export enum FieldType {
+	Status, LargeStatus, Field, User, JoinedArray, ArrayCount, DuplicateCount, Date, FromNow
+}
+
+export interface Description {
+	maxCharacters?: number;
+	maxLineBreaks?: number;
+	exclude?: RegExp[];
+}
+
+export class EmbedConfig {
+	public title: boolean;
+	public description: boolean | Description;
+	public author: boolean;
+	public url: boolean;
+	public thumbnail: boolean;
+	public color: ColorResolvable;
+	public fields: false | FieldConfig[];
+
+	constructor( json ) {
+		this.title = !!json.title;
+		if ( typeof json.description === 'object' ) {
+			this.description = {};
+			if( json.description.max_characters ) {
+				this.description.maxCharacters = json.description.max_characters;
+			}
+			if( json.description.max_line_breaks ) {
+				this.description.maxLineBreaks = json.description.max_line_breaks;
+			}
+			if( json.description.exclude ) {
+				this.description.exclude = json.description.exclude.map( v => {
+					const components = v.split( '/' ) as Array<string>;
+					if( components && components.length < 3 ) throw `Invalid regex: Not enough slashes (/) (expected: 2): ${ v }`;
+					return new RegExp( components.splice( 1, components.length - 2 ).join( '/' ), components[ components.length - 1 ] );
+				} );
+			}
+		} else {
+			this.description = false;
+		}
+
+		this.author = !!json.author;
+		this.url = !!json.url;
+		this.thumbnail = !!json.thumbnail;
+
+		if( !json.color ) throw 'An embed type has no color.';
+		this.color = json.color as ColorResolvable;
+		if( !this.color ) throw `An embed type has invalid color ${ json.color }.`;
+
+		if ( json.fields instanceof Array ) {
+			this.fields = new Array<FieldConfig>();
+
+			for( const field of json.fields ) {
+				if( !field.label ) throw 'An embed type contains a field object without any label.';
+				if( !( field.type as string ) ) throw `An embed type contains field "${ field.label }" without any type.`;
+				let type = field.type as string;
+
+				// convert snake_case to PascalCase
+				type = type.replace( /(?:^|_)./g, match => match.substring( match.length - 1, match.length ).toUpperCase() );
+
+				const fieldType = FieldType[type];
+				if( !fieldType ) throw `An embed type contains field "${ field.label }" with invalid type "${ type }".`;
+
+				if( ![ FieldType.Status, FieldType.LargeStatus, FieldType.DuplicateCount ].includes( fieldType ) && !field.path ) throw `An embed type contains field "${ field.label }" without any path.`;
+
+				this.fields.push( {
+					type: fieldType,
+					label: field.label,
+					path: field.path,
+					inline: field.inline !== undefined ? field.inline : true,
+					innerPath: field.innerPath,
+				} );
+			}
+		} else {
+			this.fields = false;
+		}
+	}
+}
+
+export default class MentionConfig {
+	public requireUrl?: boolean;
+	public forbidUrl?: boolean;
+	public requiredPrefix?: string;
+	public forbiddenPrefix?: string;
+	public requiredKeyword?: string;
+	public forbiddenKeyword?: string;
+	public embed: EmbedConfig;
+
+	constructor( json, embedTypes: Map<string, EmbedConfig> ) {
+		if( !json.embed ) throw 'Added mention type without an embed.';
+		this.embed = embedTypes.get( json.embed );
+		if( !this.embed ) throw `Added mention type with unkown embed ${ json.embed }.`;
+
+		this.requireUrl = json.require_url;
+		this.forbidUrl = json.forbid_url;
+		this.requiredPrefix = json.required_prefix;
+		this.forbiddenPrefix = json.forbidden_prefix;
+		this.requiredKeyword = json.required_keyword;
+		this.forbiddenKeyword = json.forbidden_keyword;
+	}
+}

--- a/src/commands/Command.ts
+++ b/src/commands/Command.ts
@@ -9,7 +9,7 @@ import * as log4js from 'log4js';
  * @author violine1101
  * @since 2019-12-04
  */
-export default abstract class Command {
+export default abstract class Command<T> {
 	public static logger = log4js.getLogger( 'CommandExecutor' );
 
 	public readonly permissionLevel: Permission = PermissionRegistry.ANY_PERMISSION;
@@ -25,8 +25,8 @@ export default abstract class Command {
 	 *
 	 * @param messageText The text that came with the message
 	 */
-	public abstract test( messageText: string ): boolean | string | string[];
-	public abstract async run( message: Message, args: string | string[] ): Promise<boolean>;
+	public abstract test( messageText: string ): boolean | T;
+	public abstract async run( message: Message, args: T ): Promise<boolean>;
 
-	public abstract asString( args: string | string[] ): string;
+	public abstract asString( args: string | T ): string;
 }

--- a/src/commands/CommandExecutor.ts
+++ b/src/commands/CommandExecutor.ts
@@ -5,7 +5,7 @@ import CommandRegistry from './CommandRegistry';
 export default class CommandExecutor {
 	public static async checkCommands( message: Message ): Promise<boolean> {
 		for ( const commandName in CommandRegistry ) {
-			const command = CommandRegistry[commandName] as Command;
+			const command = CommandRegistry[commandName] as Command<any>;
 
 			if ( command.checkPermission( message.member ) ) {
 				const commandTestResult = command.test( message.content );

--- a/src/commands/MentionCommand.ts
+++ b/src/commands/MentionCommand.ts
@@ -4,7 +4,6 @@ import BotConfig from '../BotConfig';
 import { Mention } from '../mentions/Mention';
 import { MultipleMention } from '../mentions/MultipleMention';
 import MentionConfig from '../MentionConfig';
-import { MentionRegistry } from '../mentions/MentionRegistry';
 import { CustomMention } from '../mentions/CustomMention';
 
 export default class MentionCommand extends Command<MentionResult> {
@@ -22,7 +21,7 @@ export default class MentionCommand extends Command<MentionResult> {
 			return false;
 		}
 
-		if( BotConfig.maxUngroupedMentions !== undefined && mentions.length > BotConfig.maxUngroupedMentions ) {
+		if( BotConfig.maxUngroupedMentions > 0 && mentions.length > BotConfig.maxUngroupedMentions ) {
 			const tickets = mentions.map( v => v.getTicket() );
 			mentions = [ new MultipleMention( tickets ) ];
 		}

--- a/src/commands/MentionCommand.ts
+++ b/src/commands/MentionCommand.ts
@@ -1,78 +1,140 @@
 import { Message, RichEmbed } from 'discord.js';
 import Command from './Command';
-import { MentionRegistry } from '../mentions/MentionRegistry';
 import BotConfig from '../BotConfig';
+import { Mention } from '../mentions/Mention';
+import { MultipleMention } from '../mentions/MultipleMention';
+import MentionConfig from '../MentionConfig';
+import { MentionRegistry } from '../mentions/MentionRegistry';
+import { CustomMention } from '../mentions/CustomMention';
 
-export default class MentionCommand extends Command {
-	public test( messageText: string ): boolean | string[] {
-		const ticketRegex = RegExp( `(?:^|[^${ BotConfig.forbiddenTicketPrefix }])${ BotConfig.requiredTicketPrefix }(${ this.getTicketPattern() })`, 'g' );
+export default class MentionCommand extends Command<MentionResult> {
+	public test( messageText: string ): boolean | MentionResult {
+		let unmatchedMessage = messageText;
+		let mentions = new Array<Mention>();
 
-		// replace all issues posted in the form of a link from the search either with a mention or remove them
-		if ( !BotConfig.ticketUrlsCauseEmbed || BotConfig.requiredTicketPrefix ) {
-			messageText = messageText.replace(
-				new RegExp( `https?://bugs.mojang.com/browse/(${ this.getTicketPattern() })`, 'g' ),
-				BotConfig.ticketUrlsCauseEmbed ? `${ BotConfig.requiredTicketPrefix }$1` : ''
-			);
+		for ( const mentionType of BotConfig.mentionTypes ) {
+			const result = this.matchEmbeds( unmatchedMessage, mentionType );
+			result.mentions.forEach( v => mentions.push( v ) );
+			unmatchedMessage = result.unmatchedMessage;
 		}
 
-		let ticketMatch: RegExpExecArray;
-		const ticketMatches: Set<string> = new Set();
-
-		while ( ( ticketMatch = ticketRegex.exec( messageText ) ) !== null ) {
-			ticketMatches.add( ticketMatch[1] );
+		if ( mentions.length == 0 ) {
+			return false;
 		}
 
-		return ticketMatches.size ? Array.from( ticketMatches ) : false;
+		if( BotConfig.maxUngroupedMentions !== undefined && mentions.length > BotConfig.maxUngroupedMentions ) {
+			const tickets = mentions.map( v => v.getTicket() );
+			mentions = [ new MultipleMention( tickets ) ];
+		}
+
+		return {
+			mentions: mentions,
+			unmatchedMessage: unmatchedMessage,
+		};
 	}
 
-	public async run( message: Message, args: string[] ): Promise<boolean> {
-		const mention = MentionRegistry.getMention( args );
+	public async run( message: Message, args: MentionResult ): Promise<boolean> {
+		const embeds = new Array<RichEmbed>();
 
-		let embed: RichEmbed;
-		try {
-			embed = await mention.getEmbed();
-		} catch ( err ) {
+		for( const mention of args.mentions ) {
+			let embed: RichEmbed;
+
 			try {
-				message.channel.send( err );
+				embed = await mention.getEmbed();
 			} catch ( err ) {
-				Command.logger.log( err );
-			}
-			return false;
-		}
-
-		if ( embed === undefined ) return false;
-
-		embed.setFooter( message.author.tag, message.author.avatarURL )
-			.setTimestamp( message.createdAt );
-
-		try {
-			await message.channel.send( embed );
-		} catch ( err ) {
-			Command.logger.error( err );
-			return false;
-		}
-
-		if ( message.deletable ) {
-			const matchesTicketId = message.content.match( new RegExp( `^\\s*${ BotConfig.requiredTicketPrefix }${ this.getTicketPattern() }\\s*$` ) );
-			const matchesTicketUrl = message.content.match( new RegExp( `^\\s*https?://bugs.mojang.com/browse/${ this.getTicketPattern() }\\s*$` ) );
-
-			if ( matchesTicketId || ( BotConfig.ticketUrlsCauseEmbed && matchesTicketUrl ) ) {
 				try {
-					message.delete();
+					message.channel.send( err );
 				} catch ( err ) {
-					Command.logger.error( err );
+					Command.logger.log( err );
 				}
+				return false;
+			}
+
+			if( embed === undefined ) return false;
+
+			embed.setFooter( message.author.tag, message.author.avatarURL )
+				.setTimestamp( message.createdAt );
+
+			embeds.push( embed );
+		}
+
+		let error = false;
+		for( const embed of embeds ) {
+			try {
+				await message.channel.send( embed );
+			} catch ( err ) {
+				Command.logger.error( err );
+				error = true;
+			}
+		}
+
+		if( error ) return false;
+
+		if ( message.deletable && args.unmatchedMessage !== undefined && args.unmatchedMessage.match( /^\s*$/g ) ) {
+			try {
+				message.delete();
+			} catch ( err ) {
+				Command.logger.error( err );
 			}
 		}
 
 		return true;
 	}
 
-	public asString( args: string[] ): string {
-		return '[mention] ' + args.join( ', ' );
+	public asString( args: MentionResult ): string {
+		const tickets = args.mentions.map( v => v.getTicket() );
+
+		return '[mention] ' + tickets.join( ', ' );
 	}
 
-	private getTicketPattern(): string {
-		return `(?:${ BotConfig.projects.join( '|' ) })-\\d+`;
+	private matchEmbeds( message: string, mentionType: MentionConfig ): { mentions: Array<Mention>; unmatchedMessage: string } {
+		if ( ( mentionType.forbiddenKeyword && message.includes( mentionType.forbiddenKeyword ) )
+			|| ( mentionType.requiredKeyword && !message.includes( mentionType.requiredKeyword ) ) ) {
+			return { mentions: [], unmatchedMessage: message };
+		}
+
+		if( mentionType.requiredKeyword ) {
+			message = message.replace( mentionType.requiredKeyword, '' );
+		}
+
+		const ticketPatern = `(?:${ BotConfig.projects.join( '|' ) })-\\d+`;
+		let ticketRegex: RegExp;
+
+		if ( mentionType.requireUrl ) {
+			ticketRegex = RegExp( `https?://bugs.mojang.com/browse/(${ ticketPatern })`, 'g' );
+		} else {
+			const getPref = ( pref: string ): string => {
+				return pref ? pref : '';
+			};
+
+			ticketRegex = RegExp( `(?:^|[^${ getPref( mentionType.forbiddenPrefix ) }])${ getPref( mentionType.requiredPrefix ) }(${ ticketPatern })`, 'g' );
+
+			// replace all issues posted in the form of a link from the search either with a mention or remove them
+			if ( !mentionType.forbidUrl || mentionType.requiredPrefix ) {
+				message = message.replace(
+					new RegExp( `https?://bugs.mojang.com/browse/(${ ticketPatern })`, 'g' ),
+					mentionType.forbidUrl ? `${ mentionType.requiredPrefix }$1` : ''
+				);
+			}
+		}
+
+		let ticketMatch: RegExpExecArray;
+		const ticketMatches = new Array<Mention>();
+		let unmatchedMessage = message;
+
+		while ( ( ticketMatch = ticketRegex.exec( message ) ) !== null ) {
+			unmatchedMessage = unmatchedMessage.replace( ticketMatch[0], '' );
+			ticketMatches.push( new CustomMention( ticketMatch[1], mentionType.embed ) );
+		}
+
+		return {
+			mentions: ticketMatches,
+			unmatchedMessage: unmatchedMessage,
+		};
 	}
+}
+
+interface MentionResult {
+	mentions: Array<Mention>;
+	unmatchedMessage: string;
 }

--- a/src/commands/PrefixCommand.ts
+++ b/src/commands/PrefixCommand.ts
@@ -1,7 +1,7 @@
 import Command from './Command';
 import escapeRegex = require( 'escape-string-regexp' );
 
-export default abstract class PrefixCommand extends Command {
+export default abstract class PrefixCommand extends Command<string> {
 	abstract readonly aliases: string[];
 
 	public static prefix = '!jira';

--- a/src/mentions/CustomMention.ts
+++ b/src/mentions/CustomMention.ts
@@ -128,8 +128,8 @@ export class CustomMention extends Mention {
 							if ( field.innerPath ) {
 								array = array.map( v => this.resolvePath( v, field.innerPath ) );
 							}
+							if( array !== undefined && array.length > 0 ) embed.addField( field.label, array.join( ', ' ), field.inline );
 						}
-						if( array.length > 0 ) embed.addField( field.label, array.join( ', ' ), field.inline );
 
 						break;
 					}
@@ -141,8 +141,8 @@ export class CustomMention extends Mention {
 							if ( field.innerPath ) {
 								array = array.map( v => this.resolvePath( v, field.innerPath ) );
 							}
+							if( array ) embed.addField( field.label, array.length, field.inline );
 						}
-						if( array ) embed.addField( field.label, array.length, field.inline );
 
 						break;
 					}

--- a/src/mentions/CustomMention.ts
+++ b/src/mentions/CustomMention.ts
@@ -1,0 +1,199 @@
+import { Mention } from './Mention';
+import JiraClient = require( 'jira-connector' );
+import { RichEmbed } from 'discord.js';
+import { EmbedConfig, FieldType } from '../MentionConfig';
+import moment = require( 'moment' );
+
+export class CustomMention extends Mention {
+	private jira: JiraClient;
+	private ticket: string;
+	private config: EmbedConfig;
+
+	constructor( ticket: string, config: EmbedConfig ) {
+		super();
+
+		this.ticket = ticket;
+		this.config = config;
+
+		this.jira = new JiraClient( {
+			host: 'bugs.mojang.com',
+			strictSSL: true,
+		} );
+	}
+
+	public async getEmbed(): Promise<RichEmbed> {
+		let ticketResult;
+
+		try {
+			ticketResult = await this.jira.issue.getIssue( {
+				issueId: this.ticket,
+			} );
+		} catch ( err ) {
+			const exception = JSON.parse( err );
+			if ( !exception ) {
+				Mention.logger.error( err );
+				return;
+			}
+
+			Mention.logger.error( 'Error: status code ' + exception.statusCode );
+
+			// TODO clean up
+			let errorMessage = `An error occurred while retrieving this ticket: ${ exception.body.errorMessages[0] }`;
+
+			if ( exception.statusCode === 404 ) {
+				errorMessage = 'This ticket doesn\'t seem to exist.';
+			} else if ( exception.statusCode === 401 ) {
+				errorMessage = 'This ticket is private or has been deleted.';
+			}
+
+			throw errorMessage;
+		}
+
+		if ( !ticketResult.fields ) {
+			Mention.logger.error( 'Error: no fields returned by JIRA' );
+
+			throw 'An error occurred while retrieving this ticket: No fields were returned by the JIRA API.';
+		}
+
+		const embed = new RichEmbed();
+		if ( this.config.title ) embed.setTitle( `[${ ticketResult.key }] ${ ticketResult.fields.summary }` );
+		if ( this.config.author ) embed.setAuthor( ticketResult.fields.reporter.displayName, ticketResult.fields.reporter.avatarUrls['48x48'], 'https://bugs.mojang.com/secure/ViewProfile.jspa?name=' + encodeURIComponent( ticketResult.fields.reporter.name ) );
+		if ( this.config.url ) embed.setURL( `https://bugs.mojang.com/browse/${ ticketResult.key }` );
+		if ( this.config.thumbnail ) embed.setImage( this.findThumbnail( ticketResult.fields.attachment ) );
+
+		if ( this.config.description ) {
+			let description = ticketResult.fields.description;
+			description = description.replace( /^\s*[\r\n]/gm, '\n' );
+
+			if ( typeof this.config.description === 'object' ) {
+				if ( this.config.description !== undefined ) {
+					for ( const regex of this.config.description.exclude ) {
+						description = description.replace( regex, '' );
+					}
+				}
+
+				if ( this.config.description.maxLineBreaks !== undefined ) description = description.split( '\n' ).slice( 0, this.config.description.maxLineBreaks ).join( '\n' );
+				if ( this.config.description.maxCharacters !== undefined ) description = description.substring( 0, this.config.description.maxCharacters );
+			}
+
+			embed.setDescription( description );
+		}
+
+		embed.setColor( this.config.color );
+
+		if ( this.config.fields ) {
+			for ( const field of this.config.fields ) {
+				switch ( +field.type ) {
+					case FieldType.Status:
+						if ( ticketResult.status.name ) embed.addField( field.label, ticketResult.status.name, field.inline );
+						break;
+
+					case FieldType.LargeStatus: {
+						let status = ticketResult.fields.status.name;
+						let largeStatus = false;
+						if ( ticketResult.fields.resolution ) {
+							const resolutionDate = moment( ticketResult.fields.resolutiondate ).fromNow();
+							status = `Resolved as **${ ticketResult.fields.resolution.name }** ${ resolutionDate }`;
+
+							if ( ticketResult.fields.resolution.id === '3' ) {
+								const parents = ticketResult.fields.issuelinks
+									.filter( relation => relation.type.id === '10102' && relation.outwardIssue )
+									.map( relation => `\n→ **[${ relation.outwardIssue.key }](https://bugs.mojang.com/browse/${ relation.outwardIssue.key })** *(${ relation.outwardIssue.fields.summary })*` );
+
+								status += parents.join( ',' );
+								largeStatus = parents.length > 0;
+							}
+						}
+
+						if( status ) embed.addField( field.label, status, field.inline && !largeStatus );
+						break;
+					}
+
+					case FieldType.Field: {
+						const value = this.resolvePath( ticketResult.fields, field.path );
+						if ( value ) embed.addField( field.label, value, field.inline );
+						break;
+					}
+
+					case FieldType.User: {
+						const user = this.resolvePath( ticketResult.fields, field.path );
+						if( user ) embed.addField( field.label, `[${ user.displayName }](https://bugs.mojang.com/secure/ViewProfile.jspa?name=${ encodeURIComponent( user.name ) })`, field.inline );
+						break;
+					}
+
+					case FieldType.JoinedArray: {
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						let array = this.resolvePath( ticketResult.fields, field.path ) as Array<any>;
+						if( array ) {
+							if ( field.innerPath ) {
+								array = array.map( v => this.resolvePath( v, field.innerPath ) );
+							}
+						}
+						if( array.length > 0 ) embed.addField( field.label, array.join( ', ' ), field.inline );
+
+						break;
+					}
+
+					case FieldType.ArrayCount: {
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						let array = this.resolvePath( ticketResult.fields, field.path ) as Array<any>;
+						if( array ) {
+							if ( field.innerPath ) {
+								array = array.map( v => this.resolvePath( v, field.innerPath ) );
+							}
+						}
+						if( array ) embed.addField( field.label, array.length, field.inline );
+
+						break;
+					}
+
+					case FieldType.DuplicateCount: {
+						const duplicates = ticketResult.fields.issuelinks.filter( relation => relation.type.id === '10102' && relation.inwardIssue );
+						if ( duplicates.length ) embed.addField( field.label, duplicates.length, field.inline );
+						break;
+					}
+
+					case FieldType.Date: {
+						const date = this.resolvePath( ticketResult.fields, field.path ) as string;
+						if ( date ) embed.addField( field.label, new Date( date ).toDateString(), field.inline );
+						break;
+					}
+
+					case FieldType.FromNow: {
+						const date = this.resolvePath( ticketResult.fields, field.path ) as string;
+						if ( date ) embed.addField( field.label, moment( date ).fromNow(), field.inline );
+
+						break;
+					}
+				}
+			}
+		}
+		return embed;
+	}
+
+	private findThumbnail( attachments ): string {
+		const allowedMimes = [
+			'image/png', 'image/jpeg',
+		];
+
+		for ( const attachment of attachments ) {
+			if ( allowedMimes.includes( attachment.mimeType ) ) return attachment.content;
+		}
+
+		return undefined;
+	}
+
+	// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+	private resolvePath( fields, path: string ) {
+		let cur = fields;
+		for ( const entry of path.split( '.' ) ) {
+			cur = cur[ entry ];
+		}
+
+		return cur;
+	}
+
+	getTicket(): string {
+		return this.ticket;
+	}
+}

--- a/src/mentions/Mention.ts
+++ b/src/mentions/Mention.ts
@@ -1,8 +1,10 @@
 import { RichEmbed } from 'discord.js';
 import * as log4js from 'log4js';
 
+
 export abstract class Mention {
 	public static logger = log4js.getLogger( 'Mention' );
 
 	abstract async getEmbed(): Promise<RichEmbed>;
+	abstract getTicket(): string;
 }

--- a/src/mentions/MultipleMention.ts
+++ b/src/mentions/MultipleMention.ts
@@ -26,7 +26,7 @@ export class MultipleMention extends Mention {
 		embed.setTitle( 'Mentioned tickets' )
 			.setColor( 'RED' );
 
-		let searchResults: any;
+		let searchResults;
 
 		try {
 			searchResults = await this.jira.search.search( {

--- a/src/mentions/MultipleMention.ts
+++ b/src/mentions/MultipleMention.ts
@@ -7,11 +7,13 @@ export class MultipleMention extends Mention {
 	private jira: JiraClient;
 
 	private tickets: string[];
+	private maxGroupedMentions: number;
 
-	constructor( tickets: string[] ) {
+	constructor( tickets: string[], maxGroupedMentions?: number ) {
 		super();
 
 		this.tickets = tickets;
+		this.maxGroupedMentions = maxGroupedMentions || BotConfig.maxGroupedMentions;
 
 		this.jira = new JiraClient( {
 			host: 'bugs.mojang.com',
@@ -29,7 +31,7 @@ export class MultipleMention extends Mention {
 		try {
 			searchResults = await this.jira.search.search( {
 				jql: `id IN (${ this.tickets.join( ',' ) }) ORDER BY key ASC`,
-				maxResults: BotConfig.maxGroupedMentions,
+				maxResults: this.maxGroupedMentions,
 				fields: [ 'key', 'summary' ],
 			} );
 		} catch ( err ) {

--- a/src/mentions/SingleMention.ts
+++ b/src/mentions/SingleMention.ts
@@ -129,4 +129,8 @@ export class SingleMention extends Mention {
 
 		return embed;
 	}
+
+	getTicket(): string {
+		return this.ticket;
+	}
 }

--- a/src/tasks/FilterFeedTask.ts
+++ b/src/tasks/FilterFeedTask.ts
@@ -1,9 +1,11 @@
-import { MentionRegistry } from '../mentions/MentionRegistry';
-import { FilterFeedConfig } from '../BotConfig';
-import { Client, TextChannel, Channel } from 'discord.js';
+import BotConfig, { FilterFeedConfig } from '../BotConfig';
+import { Client, TextChannel, Channel, RichEmbed } from 'discord.js';
 import * as log4js from 'log4js';
 import Task from './Task';
 import JiraClient = require( 'jira-connector' );
+import { EmbedConfig } from '../MentionConfig';
+import { CustomMention } from '../mentions/CustomMention';
+import { MultipleMention } from '../mentions/MultipleMention';
 
 export default class FilterFeedTask extends Task {
 	public static logger = log4js.getLogger( 'FilterFeed' );
@@ -13,16 +15,22 @@ export default class FilterFeedTask extends Task {
 	private channel: Channel;
 	private jql: string;
 	private title: string;
+	private embed: EmbedConfig;
+	private maxUngroupedMentions: number;
+	private maxGroupedMentions: number;
 	private titleSingle: string;
 
 	private knownTickets = new Set<string>();
 
-	constructor( { jql, title, title_single: titleSingle }: FilterFeedConfig, channel: Channel ) {
+	constructor( { jql, title, embed, maxUngroupedMentions: maxUngroupedMentions, maxGroupedMentions: maxGroupedMentions, titleSingle: titleSingle }: FilterFeedConfig, channel: Channel ) {
 		super();
 
 		this.channel = channel;
 		this.jql = jql;
 		this.title = title;
+		this.embed = embed;
+		this.maxUngroupedMentions = maxUngroupedMentions || BotConfig.maxUngroupedMentions;
+		this.maxGroupedMentions = maxGroupedMentions || BotConfig.maxGroupedMentions;
 		this.titleSingle = titleSingle || title.replace( /\{\{num\}\}/g, '1' );
 
 		this.jira = new JiraClient( {
@@ -56,20 +64,34 @@ export default class FilterFeedTask extends Task {
 
 			if ( unknownTickets.length > 0 ) {
 				try {
-					const embed = await MentionRegistry.getMention( unknownTickets ).getEmbed();
-
 					let message = '';
+					const embeds = new Array<RichEmbed>();
 
 					if ( unknownTickets.length > 1 ) {
-						embed.setTitle(
-							this.title.replace( /\{\{num\}\}/g, unknownTickets.length.toString() )
-						);
+						const getTitle = (): string => this.title.replace( /\{\{num\}\}/g, unknownTickets.length.toString() );
+
+						if ( unknownTickets.length > this.maxUngroupedMentions ) {
+							const embed = await new MultipleMention( unknownTickets, this.maxGroupedMentions ).getEmbed();
+							embed.setTitle( getTitle() );
+							embeds.push( embed );
+						} else {
+							message = getTitle();
+							for( const ticket of unknownTickets ) {
+								embeds.push( await new CustomMention ( ticket, this.embed ).getEmbed() );
+							}
+						}
 					} else {
 						message = this.titleSingle;
+						embeds.push( await new CustomMention ( unknownTickets[ 0 ], this.embed ).getEmbed() );
 					}
 
 					if ( this.channel instanceof TextChannel ) {
-						this.channel.send( message, embed );
+						this.channel.send( message, embeds [ 0 ] );
+						if ( embeds.length > 1 ) {
+							for ( const embed of embeds.splice( 0, embeds.length ) ) {
+								this.channel.send( embed );
+							}
+						}
 					} else {
 						throw `Expected ${ this.channel } to be a TextChannel`;
 					}

--- a/src/tasks/FilterFeedTask.ts
+++ b/src/tasks/FilterFeedTask.ts
@@ -29,7 +29,7 @@ export default class FilterFeedTask extends Task {
 		this.jql = jql;
 		this.title = title;
 		this.embed = embed;
-		this.maxUngroupedMentions = maxUngroupedMentions || BotConfig.maxUngroupedMentions;
+		this.maxUngroupedMentions = maxUngroupedMentions !== undefined ? maxUngroupedMentions : BotConfig.maxUngroupedMentions;
 		this.maxGroupedMentions = maxGroupedMentions || BotConfig.maxGroupedMentions;
 		this.titleSingle = titleSingle || title.replace( /\{\{num\}\}/g, '1' );
 
@@ -70,7 +70,7 @@ export default class FilterFeedTask extends Task {
 					if ( unknownTickets.length > 1 ) {
 						const getTitle = (): string => this.title.replace( /\{\{num\}\}/g, unknownTickets.length.toString() );
 
-						if ( unknownTickets.length > this.maxUngroupedMentions ) {
+						if ( this.maxUngroupedMentions > 0 && unknownTickets.length > this.maxUngroupedMentions ) {
 							const embed = await new MultipleMention( unknownTickets, this.maxGroupedMentions ).getEmbed();
 							embed.setTitle( getTitle() );
 							embeds.push( embed );
@@ -88,7 +88,7 @@ export default class FilterFeedTask extends Task {
 					if ( this.channel instanceof TextChannel ) {
 						this.channel.send( message, embeds [ 0 ] );
 						if ( embeds.length > 1 ) {
-							for ( const embed of embeds.splice( 0, embeds.length ) ) {
+							for ( const embed of embeds.splice( 1, embeds.length ) ) {
 								this.channel.send( embed );
 							}
 						}


### PR DESCRIPTION
This pull request makes mentions fully configurable. This includes embeds themselves.

- Different mention types with different requirements can be configured to trigger embeds (#15).
  - Mention types can require or forbid urls, prefixes and keywords (#14).
- Filter feeds also need to be assigned to a specified embed type now.
- The threshold for when a mention command's embed gets grouped is configurable as well now
  - The same is configurable per filter feed (#20)
  - Currently, this is not configurable per mention type. This would probably require a less greedy procedure for finding appropriate mention types (as in case the number is exceeded, another mention type that's also applicable with a higher threshold might be useable) 
- The maximum amount of tickets in a grouped embed is now configurable.
  - The same is configurable per filter feed (#20)
  - Configuring this per mention type doesn't really make sense, as a message can contain multiple mention types, but which one should we use for this value?
- The mention command now deletes any message that contains solely of mentions.
  - Example: If `MC-1 MC-2 MC-3` all trigger a mention, and the message does not contain anything else, the message will be deleted.
- Grouped embeds use the description now instead of fields, making them more concise
  - see also [this message thread from #bot-commands](https://discordapp.com/channels/647810384031645728/647814935572643840/680136510099423238)
  - The final look is this:
![image](https://user-images.githubusercontent.com/12124394/75498353-37ef1200-59c7-11ea-8035-fdaa12e07c0b.png)
- Old global mention configurations from #11 have been removed.

Mention types allow for these configurations:
```jsonc
// Rules for invoking different embeds when mentioning a ticket.
// In case multiple types match, the one defined first will be used.
"mention_types": [
	{
		// Optional. If set to true, this mention type will only trigger if the mentioned ticket was provided as URL.
		// Default: false
		"require_url": false,

		// Optional. If set to true, this mention type will not trigger if the mentioned ticket was provided as URL.
		// Default: false
		"forbid_url": false,

		// Optional. If set, this mention type will only trigger if the mentioned ticket was prefixed with the given string.
		// This will be ignored if require_url is set to true.
		// Default: no required prefix.
		"required_prefix": "<prefix>",

		// Optional. If set, this mention type will not trigger if the mentioned ticket was prefixed with one of the given characters.
		// This will be ignored if require_url is set to true.
		// Default: no forbidden prefix.
		"forbidden_prefix": "<prefix>",

		// Optional. If set, this mention type will only trigger if the message includes a keyword somewhere in the message.
		// Default: no required keyword.
		"required_keyword": "<keyword>",

		// Optional. If set, this mention type will not trigger if the message includes a keyword somewhere in the message.
		// Default: no forbidden keyword.
		"forbidden_keyword": "<keyword>",

		// An embed name defined in embed_types.
		// This embed will be used to display the mention.
		"embed": "<embed name>"
	}
	// ... You can add more mention types here
],
```

Embeds can be configured like this:
```jsonc
// Map of custom embed types
"embed_types": {
	"<name of an embed type>": {

		// Optional. Whether to include the embed title
		// Default: false
		"title": false,

		// Optional. Settings for the description. Either below's object or false for no description.
		// Default: false
		"description": {
			// If set, the description cannot be longer than n characters.
			"max_characters": 1234,
			// If set, the description cannot include more than n line breaks.
			"max_line_breaks": 2,
			// If set, everything from the description that matches any of the given regex strings will be stripped.
			"exclude": [ "<a regex string>" ]
		},

		// Optional. Whether the author should be included.
		// Default: false
		"author": false,
		
		// Optional. Whether the embed should link to the ticket included.
		// Default: false
		"url": false,
		
		// Optional. Whether the embed should include the first image attachment as Image.
		// Default: false
		"thumbnail": false,

		// The color the embed should have
		"color": "DiscordColorResolvable",

		// Optional. A list of additional fields that should be added. Can be set to false for no fields.
		// Default: false
		"fields": [
			{
				// Type of the field.
				// Currently available: status, large_status, field, user, joined_array, array_count, duplicate_count, date, from_now
				"type": "<type>",

				// Label the field should appear with.
				"label": "<label>",

				// Path to the field in the jira json response. See jira api documentaion for more details.
				// Path members are seperated with dots (.) And the path starts at ticketResponse.fields
				// Not needed for status, large_status and duplicate_count
				"path": "<path-to-field>",

				// Optional. Whether the field should be inline. A maximum of 3 fields will appear next to each other when set.
				// Default: true
				"inline": false,

				// Optional. Currently only for joined_array.
				// Path for object in the array that should be used for display.
				// Default: Print entire object. 
				"inner_path": "<inner path>"
			}
			// ... You can add more fields here
		]
	}
	// ... You can define moore embed types here
},
```

For example, if you wanted to define a minimalistic embed for urls and the verbose embed that is currently used, it would look like this:
```json
{
	"embed_types": {
		"minimal": {
			"title": true,
			"description": false,
			"author": false,
			"url": true,
			"thumbnail": false,
			"color": "BLUE",
			"fields": false
		},
		
		"verbose": {
			"title": true,
			"description": {
				"max_characters": 2048,
				"max_line_breaks": 3,
				"exclude": [ "/\\s*\\{panel[^}]+\\}(?:.|\\s)*?\\{panel\\}\\s*/gi" ]
			},
			"author": true,
			"url": true,
			"thumbnail": true,
			"color": "RED",
			"fields": [
				{
					"type": "large_status",
					"label": "Status"
				},
				{
					"type": "joined_array",
					"label": "Fix version/s",
					"path": "fixVersions",
					"innerPath": "name"
				},
				{
					"type": "user",
					"label": "Assignee",
					"path": "assignee"
				},
				{
					"type": "field",
					"label": "Votes",
					"path": "votes.votes"
				},
				{
					"type": "field",
					"label": "Comments",
					"path": "comment.total"
				},
				{
					"type": "duplicate_count",
					"label": "Duplicates"
				},
				{
					"type": "from_now",
					"label": "Created",
					"path": "created"
				}
			]
		}
	},
	"mention_types": [
		{
			"require_url": true,
			"forbidden_keyword": "!nomention",
			"embed": "minimal"
		},
		{
			"forbid_url": true,
			"forbidden_prefix": "!",
			"forbidden_keyword": "!nomention",
			"embed": "verbose"
		}
	],
}
```

The verbose embed is missing the creator. In the current implementation, the creator is only shown when different from the reporter.
Currently, it is not possible to define conditions.