### PR TITLE
Resolves #22

### DIFF
--- a/settings-template.jsonc
+++ b/settings-template.jsonc
@@ -82,7 +82,7 @@
 		// Optional. Defaults to `never`.
 		"prepend_response_message": "<behavior>",
 
-		// If the in `respone_message` defined message should be added to an entry in log channel
+		// Whether the in `respone_message` defined message should be added to an entry in log channel
 		// Optional. Defaults to `false`.
 		"prepend_response_message_in_log": false,
 

--- a/settings-template.jsonc
+++ b/settings-template.jsonc
@@ -77,13 +77,23 @@
 		// Optional. Defaults to 0.
 		"resolve_delay": 3000,
 
-		// Whether or not to prepend an internal request with the corresponding response message of it.
-		// A response message is something like this:
-		// @UserWhoSentTheRequest#1234 https://link-to-request
-		// > Request Text
+		// If and when the in `respone_message` defined message should be added to an entry in the internal requests channel
+		// Possible values are `never`, `when_resolved` and `always`
+		// Optional. Defaults to `never`.
+		"prepend_response_message": "<behavior>",
+
+		// If the in `respone_message` defined message should be added to an entry in log channel
+		// Optional. Defaults to `false`.
+		"prepend_response_message_in_log": false,
+
+		// The response message to be send for easy copying a message to respond to a request.
+		// Parameters are {{autor}}, {{url}} and {{message}}.
+		// {{author}} will be replaced by "@DiscordUser#1234"
+		// {{url}} will be replaced by  the link to the message https://discordapp.com/channels/.../.../...
+		// {{message}} will be replaced by the contents of the message.
 		//
-		// Optional. Defaults to false.
-		"prepend_response_message": true
+		// Optional. Defaults to an empty message.
+		"respone_message": "```\n{{author}} {{url}}\n> {{message}}\n \n```"
 	},
 
 	// The projects the bot should be able to find tickets for

--- a/src/BotConfig.ts
+++ b/src/BotConfig.ts
@@ -14,6 +14,12 @@ export interface FilterFeedConfig {
 	title_single?: string;
 }
 
+export enum PrependResonseMessage {
+	Never = 'never',
+	WhenResolved = 'when_resolved',
+	Always = 'always'
+}
+
 export interface RequestConfig {
 	channels?: string[];
 	internal_channels?: string[];
@@ -23,7 +29,9 @@ export interface RequestConfig {
 	waiting_emoji?: string;
 	suggested_emoji?: string[];
 	resolve_delay?: number;
-	prepend_response_message?: boolean;
+	prepend_response_message?: PrependResonseMessage;
+	prepend_response_message_in_log?: boolean;
+	respone_message: string;
 }
 
 export default class BotConfig {

--- a/src/BotConfig.ts
+++ b/src/BotConfig.ts
@@ -31,7 +31,7 @@ export interface RequestConfig {
 	resolve_delay?: number;
 	prepend_response_message?: PrependResonseMessage;
 	prepend_response_message_in_log?: boolean;
-	respone_message: string;
+	respone_message?: string;
 }
 
 export default class BotConfig {

--- a/src/events/requests/NewRequestEventHandler.ts
+++ b/src/events/requests/NewRequestEventHandler.ts
@@ -1,9 +1,10 @@
 import { Message, TextChannel, RichEmbed } from 'discord.js';
 import * as log4js from 'log4js';
 import EventHandler from '../EventHandler';
-import BotConfig from '../../BotConfig';
+import BotConfig, { PrependResonseMessage } from '../../BotConfig';
 import { ReactionsUtil } from '../../util/ReactionsUtil';
 import MentionCommand from '../../commands/MentionCommand';
+import { RequestsUtil } from '../../util/RequestsUtil';
 
 export default class NewRequestEventHandler implements EventHandler {
 	public readonly eventName = '';
@@ -52,8 +53,8 @@ export default class NewRequestEventHandler implements EventHandler {
 				.addField( 'Channel', origin.channel.id, true )
 				.addField( 'Message', origin.id, true )
 				.setTimestamp( new Date() );
-			const response = BotConfig.request.prepend_response_message ?
-				`\`\`\`\n${ origin.author } ${ origin.url }\n> ${ origin.content }\nxxx\`\`\`` : '';
+			const response = BotConfig.request.prepend_response_message == PrependResonseMessage.Always ?
+				RequestsUtil.getResponseMessage( origin ) : '';
 			const copy = await internalChannel.send( response, embed ) as Message;
 			if ( BotConfig.request.suggested_emoji ) {
 				ReactionsUtil.reactToMessage( copy, [...BotConfig.request.suggested_emoji] );

--- a/src/events/requests/ReopenRequestEventHandler.ts
+++ b/src/events/requests/ReopenRequestEventHandler.ts
@@ -2,7 +2,7 @@ import { User, MessageReaction } from 'discord.js';
 import * as log4js from 'log4js';
 import EventHandler from '../EventHandler';
 import TaskScheduler from '../../tasks/TaskScheduler';
-import BotConfig from '../../BotConfig';
+import BotConfig, { PrependResonseMessage } from '../../BotConfig';
 
 export default class ReopenRequestEventHandler implements EventHandler {
 	public readonly eventName = '';
@@ -12,6 +12,10 @@ export default class ReopenRequestEventHandler implements EventHandler {
 	// This syntax is used to ensure that `this` refers to the `ReopenRequestEventHandler` object
 	public onEvent = ( { emoji, message }: MessageReaction, user: User ): void => {
 		this.logger.info( `User ${ user.tag } removed '${ emoji.name }' reaction from request message '${ message.id }'` );
+
+		if ( BotConfig.request.prepend_response_message == PrependResonseMessage.WhenResolved ) {
+			message.edit( '' );
+		}
 
 		if ( message.reactions.size <= BotConfig.request.suggested_emoji.length ) {
 			this.logger.info( `Cleared message task for request message '${ message.id }'` );

--- a/src/events/requests/ResolveRequestEventHandler.ts
+++ b/src/events/requests/ResolveRequestEventHandler.ts
@@ -2,8 +2,9 @@ import { User, MessageReaction } from 'discord.js';
 import * as log4js from 'log4js';
 import EventHandler from '../EventHandler';
 import TaskScheduler from '../../tasks/TaskScheduler';
-import BotConfig from '../../BotConfig';
+import BotConfig, { PrependResonseMessage } from '../../BotConfig';
 import ResolveRequestMessageTask from '../../tasks/ResolveRequestMessageTask';
+import { RequestsUtil } from '../../util/RequestsUtil';
 
 export default class ResolveRequestEventHandler implements EventHandler {
 	public readonly eventName = '';
@@ -11,10 +12,16 @@ export default class ResolveRequestEventHandler implements EventHandler {
 	private logger = log4js.getLogger( 'ResolveRequestEventHandler' );
 
 	// This syntax is used to ensure that `this` refers to the `ResolveRequestEventHandler` object
-	public onEvent = ( reaction: MessageReaction, user: User ): void => {
+	public onEvent = async ( reaction: MessageReaction, user: User ): Promise<void> => {
 		this.logger.info( `User ${ user.tag } added '${ reaction.emoji.name }' reaction to request message '${ reaction.message.id }'` );
 
 		TaskScheduler.clearMessageTasks( reaction.message );
+
+		if ( BotConfig.request.prepend_response_message == PrependResonseMessage.WhenResolved ) {
+			const origin = await RequestsUtil.getOriginMessage( reaction.message );
+			reaction.message.edit( RequestsUtil.getResponseMessage( origin ) );
+		}
+
 		TaskScheduler.addOneTimeMessageTask(
 			reaction.message,
 			new ResolveRequestMessageTask( reaction.emoji, user ),

--- a/src/util/RequestsUtil.ts
+++ b/src/util/RequestsUtil.ts
@@ -1,4 +1,6 @@
-import { Message } from 'discord.js';
+import { Message, TextChannel } from 'discord.js';
+import MojiraBot from '../MojiraBot';
+import BotConfig from '../BotConfig';
 
 export class RequestsUtil {
 	public static getOriginIds( message: Message ): {channelId: string; messageId: string} | undefined {
@@ -20,5 +22,23 @@ export class RequestsUtil {
 		}
 
 		return undefined;
+	}
+
+	public static async getOriginMessage( internalMessage: Message ): Promise<Message | undefined> {
+		const ids = this.getOriginIds( internalMessage );
+
+		if ( !ids ) {
+			return undefined;
+		}
+
+		const originChannel = MojiraBot.client.channels.get( ids.channelId ) as TextChannel;
+		return await originChannel.fetchMessage( ids.messageId );
+	}
+
+	public static getResponseMessage( message: Message ): string {
+		return ( BotConfig.request.respone_message || '' )
+			.replace( '{{author}}', `@${ message.author.tag }` )
+			.replace( '{{url}}', message.url )
+			.replace( '{{message}}', message.content );
 	}
 }


### PR DESCRIPTION
* It is now configurable that the response message should only be added when a volunteer resolved it.
* It is now configurable to show response messages in the request log.
* The content of the response message itself is now configurable with parameters {{author}}, {{url}} and {{message}}.