### PR TITLE
Added option to save log files to a directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 settings.json
 .vscode/*
 .history
+**/*.log

--- a/settings-template.jsonc
+++ b/settings-template.jsonc
@@ -3,8 +3,13 @@
 	// Don't add your `settings.json` to the repository, as these settings can be used very easily to control your bot without your consent if made public!
 	// The lines beginning with two slashes are comments and don't need to be included.
 
-	// Whether or not the bot is in debug mode
+	// Optional. Whether or not the bot is in debug mode
+	// Default: false 
 	"debug": false,
+	
+	// Optional. The directory to save logs to; or false to disable saving log files.
+	// Default: false 
+	"log_dir": "<dir>",
 
 	// Your bot token to login with the bot
 	"token": "<Discord bot token>",

--- a/src/BotConfig.ts
+++ b/src/BotConfig.ts
@@ -28,6 +28,7 @@ export interface RequestConfig {
 
 export default class BotConfig {
 	public static debug: boolean;
+	public static logDirectory: false | string;
 
 	private static token: string;
 	public static owner: string;
@@ -62,6 +63,9 @@ export default class BotConfig {
 
 		if ( !settings.debug ) this.debug = false;
 		else this.debug = settings.debug;
+
+		if ( !settings.log_dir ) this.logDirectory = false;
+		else this.logDirectory = settings.log_dir;
 
 		if ( !settings.token ) throw 'Token is not set';
 		this.token = settings.token;

--- a/src/MojiraBot.ts
+++ b/src/MojiraBot.ts
@@ -24,6 +24,25 @@ export default class MojiraBot {
 	private static running = false;
 
 	public static async start(): Promise<void> {
+		const logConfig: log4js.Configuration = {
+			appenders: {
+				out: { type: 'stdout' },
+			},
+			categories: {
+				default: { appenders: [ 'out' ], level: BotConfig.debug ? 'debug' : 'warn' },
+			},
+		};
+
+		if ( BotConfig.logDirectory ) {
+			logConfig.appenders.log = {
+				type: 'file',
+				filename: `${ BotConfig.logDirectory }/${ new Date().toJSON().replace( /[:.]/g, '_' ) }.log`,
+			};
+			logConfig.categories.default.appenders.push( 'log' );
+		}
+
+		log4js.configure( logConfig );
+
 		if ( this.running ) {
 			this.logger.error( 'MojiraBot is still running. You can only start a bot that is not currently running.' );
 			return;
@@ -38,6 +57,10 @@ export default class MojiraBot {
 
 			if ( BotConfig.debug ) {
 				this.logger.info( 'Debug mode is activated' );
+			}
+
+			if ( BotConfig.logDirectory ) {
+				this.logger.debug( `Writing log to ${ logConfig.appenders.log[ 'filename' ] }` );
 			}
 
 			// Register events.
@@ -116,6 +139,7 @@ export default class MojiraBot {
 			await this.client.destroy();
 			this.running = false;
 			this.logger.info( 'MojiraBot has been successfully shut down.' );
+			log4js.shutdown( ( err ) => err && console.log( err ) );
 		} catch ( err ) {
 			this.logger.error( `MojiraBot could not be shut down: ${ err }` );
 		}


### PR DESCRIPTION
Implements #34 

Adds a config option for logging to a file.

* The directory can be configured in settings.json
* The file will be named in the scheme of `YYYY-MM-DDThh_mm_ss_millisZ.log`, e.g. `2020-03-12T11_24_07_488Z.log`