### PR TITLE
Revert type change from #42

### DIFF
--- a/src/commands/RolesCommand.ts
+++ b/src/commands/RolesCommand.ts
@@ -23,7 +23,7 @@ export default class RolesCommand extends PrefixCommand {
 			embed.addField( textEmoji, role.desc );
 		}
 
-		let sentMessage: Message;
+		let sentMessage: Message | Message[];
 		try {
 			sentMessage = await channel.send( embed );
 		} catch ( err ) {
@@ -31,7 +31,16 @@ export default class RolesCommand extends PrefixCommand {
 			return false;
 		}
 
-		ReactionsUtil.reactToMessage( sentMessage, BotConfig.roles.map( role => role.emoji ) );
+		if ( sentMessage instanceof Array ) {
+			if ( sentMessage.length !== 1 ) {
+				Command.logger.error( 'Result of send command was not exactly one message' );
+				return false;
+			} else {
+				sentMessage = sentMessage[0];
+			}
+		}
+
+		ReactionsUtil.reactToMessage( sentMessage as Message, BotConfig.roles.map( role => role.emoji ) );
 
 		return true;
 	}


### PR DESCRIPTION
I'm not exactly sure why the pipelines and various checks didn't fail, but when deploying the bot, it (correctly) threw an error message.

The type change from #42 was incorrect and should not have been done (I simply overlooked the existance of one overload, and VS Code did not show the correct one in the tooltip), but neither the compiler nor VS Code did output any errors.

This might have been a TypeScript bug. Needs further investigation.