### PR TITLE
The variable {{message}} of response messages is now replaced with a quoted message

### DIFF
--- a/settings-template.jsonc
+++ b/settings-template.jsonc
@@ -95,10 +95,10 @@
 		// Parameters are {{autor}}, {{url}} and {{message}}.
 		// {{author}} will be replaced by "@DiscordUser#1234"
 		// {{url}} will be replaced by  the link to the message https://discordapp.com/channels/.../.../...
-		// {{message}} will be replaced by a qoute of the contents of the message.
+		// {{message}} will be replaced by a quote of the contents of the message.
 		//
 		// Optional. Defaults to an empty message.
-		"response_message": "```\n{{author}} {{url}}\n{{message}}\n \n```"
+		"response_message": "```\n{{author}} {{url}}\n{{message}}\n\n```"
 	},
 
 	// The projects the bot should be able to find tickets for

--- a/settings-template.jsonc
+++ b/settings-template.jsonc
@@ -95,10 +95,10 @@
 		// Parameters are {{autor}}, {{url}} and {{message}}.
 		// {{author}} will be replaced by "@DiscordUser#1234"
 		// {{url}} will be replaced by  the link to the message https://discordapp.com/channels/.../.../...
-		// {{message}} will be replaced by the contents of the message.
+		// {{message}} will be replaced by a qoute of the contents of the message.
 		//
 		// Optional. Defaults to an empty message.
-		"response_message": "```\n{{author}} {{url}}\n> {{message}}\n \n```"
+		"response_message": "```\n{{author}} {{url}}\n{{message}}\n \n```"
 	},
 
 	// The projects the bot should be able to find tickets for

--- a/src/util/RequestsUtil.ts
+++ b/src/util/RequestsUtil.ts
@@ -39,6 +39,6 @@ export class RequestsUtil {
 		return ( BotConfig.request.response_message || '' )
 			.replace( '{{author}}', `@${ message.author.tag }` )
 			.replace( '{{url}}', message.url )
-			.replace( '{{message}}', message.content );
+			.replace( '{{message}}', message.content.replace( /(^|\n)/g, '$1> ' ) );
 	}
 }


### PR DESCRIPTION
Fixes #47.
Requires config change, as `{{message}}` in `response_message` will now be replaced with a properly quoted message instead of just the message.