### PR TITLE
Fix :mojira: emote ID in help command

### DIFF
--- a/src/commands/HelpCommand.ts
+++ b/src/commands/HelpCommand.ts
@@ -8,7 +8,7 @@ export default class HelpCommand extends PrefixCommand {
 	public async run( message: Message ): Promise<boolean> {
 		try {
 			await message.channel.send(
-				`<:mojira:648521745367695370> MojiraBot help <:mojira:648521745367695370>
+				`<:mojira:716988575304122370> MojiraBot help <:mojira:716988575304122370>
 
 				This is a bot that links to a Mojira ticket when its ticket number is mentioned.
 				Currently, the following projects are supported: ${ BotConfig.projects.join( ', ' ) }


### PR DESCRIPTION
When the Mojira logo changed to match the [new Mojang Studios logo](https://www.minecraft.net/en-us/article/meet-mojang-studios) the :mojira: emote was replaced. This caused the internal Discord emote ID to change. Unfortunately, Discord doesn't have a feature to access customs emotes without hardcoding the ID, so this is liable to break if the emote ID ever changes again.