### PR TITLE
Delete signatures folder from master branch

### DIFF
--- a/signatures/version1/cla.json
+++ b/signatures/version1/cla.json
@@ -1,3 +1,0 @@
-{
-  "signedContributors": []
-}


### PR DESCRIPTION
The signatures folder is not needed on the master branch (only on `cla`) and is only there because I messed up when I set up the CLA.