### PR TITLE
Automatically publish feed messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,29 @@
       "integrity": "sha512-ASYsaKecA7TUsDrqIGPNk3JeEox0z/0XR/WsJJ8BIX/9+SkMSImQXKWfU/yBrSyc7ZSE/NPqLu36Nur0miCFfQ==",
       "dev": true
     },
+    "@types/node-fetch": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
+      "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@typescript-eslint/eslint-plugin": {
       "version": "2.27.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.27.0.tgz",
@@ -1108,6 +1131,11 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "oauth": {
       "version": "0.9.15",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,13 @@
     "jira-connector": "^3.1.0",
     "log4js": "^6.1.2",
     "moment": "^2.24.0",
+    "node-fetch": "^2.6.0",
     "typescript": "^3.8.3"
   },
   "devDependencies": {
     "@types/emoji-regex": "^8.0.0",
     "@types/node": "^12.12.35",
+    "@types/node-fetch": "^2.5.7",
     "@typescript-eslint/eslint-plugin": "^2.27.0",
     "@typescript-eslint/parser": "^2.27.0",
     "eslint": "^6.8.0"

--- a/src/BotConfig.ts
+++ b/src/BotConfig.ts
@@ -45,7 +45,8 @@ export default class BotConfig {
 	public static debug: boolean;
 	public static logDirectory: false | string;
 
-	private static token: string;
+	// TODO: make private again when /crosspost api endpoint is implemented into discord.js
+	public static token: string;
 	public static owner: string;
 
 	// Add map of id => GuildConfiguration here later

--- a/src/tasks/FilterFeedTask.ts
+++ b/src/tasks/FilterFeedTask.ts
@@ -4,6 +4,7 @@ import { Client, TextChannel, Channel } from 'discord.js';
 import * as log4js from 'log4js';
 import Task from './Task';
 import JiraClient from 'jira-connector';
+import { NewsUtil } from '../util/NewsUtil';
 
 export default class FilterFeedTask extends Task {
 	public static logger = log4js.getLogger( 'FilterFeed' );
@@ -69,7 +70,8 @@ export default class FilterFeedTask extends Task {
 					}
 
 					if ( this.channel instanceof TextChannel ) {
-						this.channel.send( message, embed );
+						const filterFeedMessage = await this.channel.send( message, embed );
+						NewsUtil.publishMessage( filterFeedMessage );
 					} else {
 						throw `Expected ${ this.channel } to be a TextChannel`;
 					}

--- a/src/tasks/VersionFeedTask.ts
+++ b/src/tasks/VersionFeedTask.ts
@@ -3,6 +3,7 @@ import Task from './Task';
 import { Channel, TextChannel, RichEmbed } from 'discord.js';
 import { VersionFeedConfig } from '../BotConfig';
 import JiraClient from 'jira-connector';
+import { NewsUtil } from '../util/NewsUtil';
 
 interface JiraVersion {
 	id: string;
@@ -67,7 +68,8 @@ export default class VersionFeedTask extends Task {
 		const changes = await this.getVersionChanges( this.cachedVersions, currentVersions );
 
 		for ( const change of changes ) {
-			await this.channel.send( change.message, change.embed );
+			const versionFeedMessage = await this.channel.send( change.message, change.embed );
+			NewsUtil.publishMessage( versionFeedMessage );
 		}
 
 		this.cachedVersions = currentVersions;

--- a/src/util/NewsUtil.ts
+++ b/src/util/NewsUtil.ts
@@ -1,0 +1,29 @@
+import { Message, NewsChannel } from 'discord.js';
+import * as log4js from 'log4js';
+import fetch, { Request, Headers } from 'node-fetch';
+import BotConfig from '../BotConfig';
+
+export class NewsUtil {
+	private static logger = log4js.getLogger( 'NewsUtil' );
+
+	public static async publishMessage( message: Message ): Promise<void> {
+		if ( !( message.channel instanceof NewsChannel ) ) return;
+
+		const request = new Request(
+			`https://discord.com/api/v6/channels/${ message.channel.id }/messages/${ message.id }/crosspost`,
+			{
+				method: 'POST',
+				headers: new Headers( {
+					'Authorization': `Bot ${ BotConfig.token }`,
+				} ),
+			}
+		);
+
+		try {
+			await fetch( request );
+			this.logger.info( `Crossposted message ${ message.id } in channel ${ message.channel.name } (${ message.channel.id })` );
+		} catch ( error ) {
+			this.logger.error( error );
+		}
+	}
+}


### PR DESCRIPTION
Closes #73.

This makes the bot automatically publish its messages from feeds (version and filter feeds) if it has been posted in an announcement (news) channel.

Tested on the Mojira Server with a second instance of MojiraBot, and it seems to work great.

Needs to be rewritten when this feature is integrated into discord.js.