### PR TITLE
Add force flag to rm command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
         key: ${{ secrets.SSH_PRIVATE_KEY }}
         command: |
           cd mojira-discord-bot
-          find ./config -type f -not -name 'local.yml' -a -not -name 'local-*.yml' -print0 | xargs -0 rm
+          find ./config -type f -not -name 'local.yml' -a -not -name 'local-*.yml' -print0 | xargs -0 rm -f
         args: "-tt"
 
     - name: Update config


### PR DESCRIPTION
Previously the command failed for an (almost) empty folder, now it should no longer do that! (Hopefully.)