### PR TITLE
Fix incorrect IDs in main config

### DIFF
--- a/config/main.yml
+++ b/config/main.yml
@@ -2,9 +2,9 @@
 
 owner: '417403221863301130'
 
-homeChannel: '649027251010142228'
-rolesChannel: '653602305417150475'
-rolesMessage: '654300040239775784'
+homeChannel: '646317855234850818'
+rolesChannel: '648479533246316555'
+rolesMessage: '692405794305736816'
 
 request:
   channels:


### PR DESCRIPTION
Apparently I put the wrong channel / message IDs into the main config, these are channels that the main bot doesn't even have access to. Hopefully this should be everything that's wrong.