### PR TITLE
Make single ticket embeds smaller

### DIFF
--- a/src/mentions/SingleMention.ts
+++ b/src/mentions/SingleMention.ts
@@ -2,6 +2,7 @@ import { RichEmbed } from 'discord.js';
 import { Mention } from './Mention';
 import JiraClient from 'jira-connector';
 import moment from 'moment';
+import { MarkdownUtil } from '../util/MarkdownUtil';
 
 export class SingleMention extends Mention {
 	private jira: JiraClient;
@@ -71,33 +72,20 @@ export class SingleMention extends Mention {
 
 		let description = ticketResult.fields.description || '';
 
-		// remove panels
-		description = description.replace( /\s*\{panel[^}]+\}(?:.|\s)*?\{panel\}\s*/gi, '' );
-
 		// unify line breaks
 		description = description.replace( /^\s*[\r\n]/gm, '\n' );
 
+		// convert to Discord markdown
+		description = MarkdownUtil.jira2md( description );
+
 		// remove headings
-		description = description.replace( /^\s*h\d.*$/mi, '' );
-		description = description.replace( /^\*.+\*$/gm, '' );
+		description = description.replace( /^#.*$/mi, '' );
 
 		// remove empty lines
-		description = description.replace( /^\s*$/gm, '' );
+		description = description.replace( /(^|\n)\s*(\n|$)/g, '\n' );
 
 		// remove all sections except for the first
-		description = description.replace( /\nh\d[\s\S]*$/i, '' );
-
-		// replace code block format
-		description = description.replace( /\{\{(.+?)\}\}/gm, '`$1`' );
-
-		// replace bold format
-		description = description.replace( /\*(.+?)\*/gm, '**$1**' );
-
-		// replace strikethrough format
-		description = description.replace( /-(.+?)\*/gm, '~~$1~~' );
-
-		// replace link format
-		description = description.replace( /\[(.+?)\|(\S+?)\]/gm, '[$1]($2)' );
+		description = description.replace( /\n#[\s\S]*$/i, '' );
 
 		// only show first two lines
 		description = description.split( '\n' ).slice( 0, 2 ).join( '\n' );

--- a/src/mentions/SingleMention.ts
+++ b/src/mentions/SingleMention.ts
@@ -78,8 +78,8 @@ export class SingleMention extends Mention {
 		// convert to Discord markdown
 		description = MarkdownUtil.jira2md( description );
 
-		// remove headings
-		description = description.replace( /^#.*$/mi, '' );
+		// remove first heading
+		description = description.replace( /^#.*$/m, '' );
 
 		// remove empty lines
 		description = description.replace( /(^|\n)\s*(\n|$)/g, '\n' );

--- a/src/util/MarkdownUtil.ts
+++ b/src/util/MarkdownUtil.ts
@@ -1,0 +1,57 @@
+export class MarkdownUtil {
+	/**
+	 * Converts JIRA markdown to Discord markdown + headings
+	 * Partially adapted from https://github.com/kylefarris/J2M
+	 *
+	 * @param text The text that should be converted
+	 */
+	public static jira2md( text: string ): string {
+		return text
+			// Unordered lists
+			.replace(
+				/^[ \t]*(#+)\s+/gm,
+				( match, nums ) => Array( nums.length ).join( '    ' ) + '1. '
+			)
+			// Headers 1-6
+			.replace(
+				/^h([0-6])\.(.*)$/gm,
+				( match, level, content ) => Array( parseInt( level ) + 1 ).join( '#' ) + content
+			)
+			// Bold
+			.replace( /\*(\S.*)\*/g, '**$1**' )
+			// Italic
+			.replace( /_(\S.*)_/g, '*$1*' )
+			// Monospaced text
+			.replace( /\{\{([^}]+)\}\}/g, '`$1`' )
+			// Inserts / underline
+			.replace( /\+([^+]*)\+/g, '__$1__' )
+			// Remove superscript
+			.replace( /\^([^^]*)\^/g, '$1' )
+			// Remove subscript
+			.replace( /~([^~]*)~/g, '$1' )
+			// Strikethrough
+			.replace( /(\s+)-(\S+.*?\S)-(\s+)/g, '$1~~$2~~$3' )
+			// Code Block
+			.replace( /\{code(:([a-z]+))?([:|]?(title|borderStyle|borderColor|borderWidth|bgColor|titleBGColor)=.+?)*\}([^]*?)\n?\{code\}/gm, '```$2$5\n```' )
+			// Pre-formatted text
+			.replace( /{noformat}/g, '```' )
+			// Un-named Links
+			.replace( /\[([^|]+?)\]/g, '$1' )
+			// Remove images
+			.replace( /!(.+)!/g, '' )
+			// Named links
+			.replace( /\[(.+?)\|(.+?)\]/g, '[$1]($2)' )
+			// Single paragraph block quote
+			.replace( /^bq\.\s+/gm, '> ' )
+			// Block quote
+			.replace( /\{quote\}\s*([\s\S]+)\{quote\}/, ( match, quote ) => quote.replace( /^(.+)$/gm, '> $1\n' ) )
+			// Remove color
+			.replace( /\{color:[^}]+\}([^]*)\{color\}/gm, '$1' )
+			// Remove panel
+			.replace( /\{panel:title=([^}]*)\}\n?([^]*?)\n?\{panel\}/gm, '' )
+			// Remove table header
+			.replace( /^[ \t]*((\|\|.*?)+\|\|)[ \t]*$/gm, '' )
+			// Remove table rows
+			.replace( /^[ \t]*((\|.*?)+\|)[ \t]*$/gm, '' );
+	}
+}


### PR DESCRIPTION
This PR changes some things about single ticket embeds, so that they are not as large as before.

* Screenshots are now always thumbnails
* Text of the ticket is displayed as short as possible