### PR TITLE
Fix grammar for single tickets in filter feed

### DIFF
--- a/src/BotConfig.ts
+++ b/src/BotConfig.ts
@@ -60,7 +60,7 @@ export interface FilterFeedConfig {
 	jql: string;
 	channel: string;
 	title: string;
-	title_single?: string;
+	titleSingle?: string;
 }
 
 export interface VersionFeedConfig {

--- a/src/tasks/FilterFeedTask.ts
+++ b/src/tasks/FilterFeedTask.ts
@@ -18,7 +18,7 @@ export default class FilterFeedTask extends Task {
 
 	private knownTickets = new Set<string>();
 
-	constructor( { jql, title, title_single: titleSingle }: FilterFeedConfig, channel: Channel ) {
+	constructor( { jql, title, titleSingle }: FilterFeedConfig, channel: Channel ) {
 		super();
 
 		this.channel = channel;


### PR DESCRIPTION
The `titleSingle` config did not work, this PR changes it so that the grammar is correct.