### PR TITLE
Make version feed actions configurable

### DIFF
--- a/config/beta.yml
+++ b/config/beta.yml
@@ -39,3 +39,10 @@ versionFeeds:
   - project: MC
     channel: '665904688616701953'
     scope: 5
+    actions:
+      - created
+      - archived
+      - unarchived
+      - released
+      - unreleased
+      - renamed

--- a/config/main.yml
+++ b/config/main.yml
@@ -52,3 +52,6 @@ versionFeeds:
   - project: MC
     channel: '666349583227682819'
     scope: 5
+    actions:
+      - released
+      - renamed

--- a/config/main.yml
+++ b/config/main.yml
@@ -54,4 +54,5 @@ versionFeeds:
     scope: 5
     actions:
       - released
+      - unreleased
       - renamed

--- a/config/template.yml
+++ b/config/template.yml
@@ -155,6 +155,11 @@ filterFeeds:
 
     # How many versions should be monitored; only the x latest versions are monitored.
     scope: <version>
+
+    # A list of actions that should be included in the version feed
+    actions:
+      - <'created' | 'released' | 'unreleased' | 'archived' | 'unarchived' | 'renamed'>
+      - ...
   
   - <see above>
   - ...

--- a/src/BotConfig.ts
+++ b/src/BotConfig.ts
@@ -1,6 +1,7 @@
 import { Client } from 'discord.js';
 import config from 'config';
 import MojiraBot from './MojiraBot';
+import { VersionChangeType } from './tasks/VersionFeedTask';
 
 function getOrDefault<T>( configPath: string, defaultValue: T ): T {
 	if ( !config.has( configPath ) ) MojiraBot.logger.debug( `config ${ configPath } not set, assuming default` );
@@ -67,6 +68,7 @@ export interface VersionFeedConfig {
 	project: string;
 	channel: string;
 	scope: number;
+	actions: VersionChangeType[];
 }
 
 export default class BotConfig {


### PR DESCRIPTION
This makes version feeds completely configurable, so that we can decide what actions we want to have included in the feed.