### PR TITLE
Fix lint command and make code style consistent

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "bot": "tsc && node bin",
     "build": "tsc",
     "validate": "tsc --noEmit",
-    "lint": "eslint **/*.ts",
-    "lintfix": "eslint **/*.ts --fix"
+    "lint": "eslint src/**/*.ts",
+    "lintfix": "eslint src/**/*.ts --fix"
   },
   "dependencies": {
     "config": "^3.3.1",

--- a/src/commands/PingCommand.ts
+++ b/src/commands/PingCommand.ts
@@ -10,7 +10,7 @@ export default class PingCommand extends PrefixCommand {
 		}
 
 		try {
-			await message.channel.send( `${message.author.toString()} Pong!` );
+			await message.channel.send( `${ message.author.toString() } Pong!` );
 		} catch {
 			return false;
 		}

--- a/src/mentions/MultipleMention.ts
+++ b/src/mentions/MultipleMention.ts
@@ -23,6 +23,7 @@ export class MultipleMention extends Mention {
 		embed.setTitle( 'Mentioned tickets' )
 			.setColor( 'RED' );
 
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		let searchResults: any;
 
 		try {

--- a/src/mentions/SingleMention.ts
+++ b/src/mentions/SingleMention.ts
@@ -20,6 +20,7 @@ export class SingleMention extends Mention {
 	}
 
 	public async getEmbed(): Promise<RichEmbed> {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		let ticketResult: any;
 
 		try {


### PR DESCRIPTION
## Purpose
The lint command didn't work properly before and only checked the files directly in the `src` directory.

## Approach
Let the lint command check all files in the `src` directory and all its subfolders by using the `src/**/*.ts` glob pattern instead of `**/*.ts`

Additionally I made sure that the whole code base complies with the eslint rules.

## Future work
Be annoyed by eslint throwing errors!