### PR TITLE
Fix #7 (Bot does not reconnect after being disconnected)

### DIFF
--- a/src/MojiraBot.ts
+++ b/src/MojiraBot.ts
@@ -13,6 +13,7 @@ import MessageDeleteEventHandler from './events/MessageDeleteEventHandler';
 import MessageUpdateEventHandler from './events/MessageUpdateEventHandler';
 import VersionFeedTask from './tasks/VersionFeedTask';
 import NewRequestEventHandler from './events/requests/NewRequestEventHandler';
+import DisconnectEventHandler from './events/DisconnectEventHandler';
 
 /**
  * Core class of MojiraBot
@@ -42,7 +43,7 @@ export default class MojiraBot {
 			// Register events.
 			EventRegistry.setClient( this.client );
 			EventRegistry.add( new ErrorEventHandler() );
-			EventRegistry.add( new RemoveReactionEventHandler( this.client.user.id ) );
+			EventRegistry.add( new DisconnectEventHandler() );
 
 			const rolesChannel = this.client.channels.get( BotConfig.rolesChannel );
 			if ( rolesChannel && rolesChannel instanceof TextChannel ) {
@@ -113,6 +114,7 @@ export default class MojiraBot {
 				}
 			}
 			EventRegistry.add( new AddReactionEventHandler( this.client.user.id, internalChannels ) );
+			EventRegistry.add( new RemoveReactionEventHandler( this.client.user.id ) );
 			EventRegistry.add( new MessageEventHandler( this.client.user.id, internalChannels ) );
 			EventRegistry.add( new MessageUpdateEventHandler( this.client.user.id, internalChannels ) );
 			EventRegistry.add( new MessageDeleteEventHandler( this.client.user.id, internalChannels ) );
@@ -152,6 +154,13 @@ export default class MojiraBot {
 			} );
 		} catch ( err ) {
 			this.logger.error( `MojiraBot could not be started: ${ err }` );
+		}
+	}
+
+	public static async reconnect(): Promise<void> {
+		const loginResult = await BotConfig.login( this.client );
+		if ( !loginResult ) {
+			MojiraBot.logger.error( 'MojiraBot was unable to reconnect' );
 		}
 	}
 

--- a/src/MojiraBot.ts
+++ b/src/MojiraBot.ts
@@ -157,10 +157,18 @@ export default class MojiraBot {
 		}
 	}
 
-	public static async reconnect(): Promise<void> {
+	public static async reconnect( tries = 0 ): Promise<void> {
 		const loginResult = await BotConfig.login( this.client );
 		if ( !loginResult ) {
-			MojiraBot.logger.error( 'MojiraBot was unable to reconnect' );
+			MojiraBot.logger.error( 'MojiraBot was unable to reconnect.' );
+
+			// Try reconnecting for 10 minutes
+			if ( tries <= 60 ) {
+				setTimeout( () => MojiraBot.reconnect( tries + 1 ), 10000 );
+			} else {
+				MojiraBot.logger.error( 'MojiraBot is shutting down.' );
+				MojiraBot.shutdown();
+			}
 		}
 	}
 

--- a/src/events/DisconnectEventHandler.ts
+++ b/src/events/DisconnectEventHandler.ts
@@ -1,0 +1,10 @@
+import EventHandler from './EventHandler';
+import MojiraBot from '../MojiraBot';
+
+export default class DisconnectEventHandler implements EventHandler {
+	public readonly eventName = 'disconnect';
+
+	public onEvent = (): void => {
+		MojiraBot.reconnect();
+	};
+}


### PR DESCRIPTION
So apparently, this branch was forgotten about since January. I just came across it while cleaning up some local branches.

## Purpose
Try to reconnect if the client gets disconnected from Discord for whatever reason.

## Approach
Listen for the disconnect event, and when it happens, try to reconnect every 10 seconds for 10 minutes. If after that the bot is still unable to reconnect, shut down the bot.

## Future work
When we upgrade to discord.js 12, we need to investigate whether there's some better (perhaps built-in?) way to handle this.