### PR TITLE
Allow multiple role selection messages

### DIFF
--- a/config/beta.yml
+++ b/config/beta.yml
@@ -13,7 +13,7 @@ request:
     - '681145724364259438'
   logChannel: '681145896247099618'
 
-roleGroupos:
+roleGroups:
   - prompt: Please select the project(s) you are interested in, so that we can add you to the appropriate channels.
     channelId: '653602305417150475'
     messageId: '654300040239775784'

--- a/config/beta.yml
+++ b/config/beta.yml
@@ -15,8 +15,8 @@ request:
 
 roleGroups:
   - prompt: Please select the project(s) you are interested in, so that we can add you to the appropriate channels.
-    channelId: '653602305417150475'
-    messageId: '654300040239775784'
+    channel: '653602305417150475'
+    message: '654300040239775784'
     radio: false
     roles:
       - emoji: '651840398859304961'

--- a/config/beta.yml
+++ b/config/beta.yml
@@ -5,8 +5,6 @@ debug: true
 owner: '417403221863301130'
 
 homeChannel: '649027251010142228'
-rolesChannel: '653602305417150475'
-rolesMessage: '654300040239775784'
 
 request:
   channels:
@@ -15,19 +13,24 @@ request:
     - '681145724364259438'
   logChannel: '681145896247099618'
 
-roles:
-  - emoji: '651840398859304961'
-    desc: Test 1
-    id: '654297808286777404'
-  - emoji: '651840436515897354'
-    desc: Test 2
-    id: '654297834241130507'
-  - emoji: '651840478957797420'
-    desc: Test 3
-    id: '654297849902661673'
-  - emoji: '654297985835859978'
-    desc: Test 4
-    id: '654297862867517441'
+roleGroupos:
+  - prompt: Please select the project(s) you are interested in, so that we can add you to the appropriate channels.
+    channelId: '653602305417150475'
+    messageId: '654300040239775784'
+    radio: false
+    roles:
+      - emoji: '651840398859304961'
+        desc: Test 1
+        id: '654297808286777404'
+      - emoji: '651840436515897354'
+        desc: Test 2
+        id: '654297834241130507'
+      - emoji: '651840478957797420'
+        desc: Test 3
+        id: '654297849902661673'
+      - emoji: '654297985835859978'
+        desc: Test 4
+        id: '654297862867517441'  
 
 filterFeeds:
   - jql: created > -1m

--- a/config/main.yml
+++ b/config/main.yml
@@ -3,8 +3,6 @@
 owner: '417403221863301130'
 
 homeChannel: '646317855234850818'
-rolesChannel: '648479533246316555'
-rolesMessage: '692405794305736816'
 
 request:
   channels:
@@ -21,26 +19,52 @@ request:
     - '692382871578607767'
   logChannel: '683039388825026562'
 
-roles:
-  - id: '648536573675044865'
-    desc: |-
-      Java Edition
-      _PC, Mac and Linux_
-    emoji: '648525192414494730'
-  - id: '648536590481752074'
-    desc: |-
-      Bedrock Edition
-      _Android, iOS, Windows 10, Xbox One, Nintendo Switch and Playstation 4_
-    emoji: '648474430158405642'
-  - id: '648536605094707201'
-    desc: 'Minecraft: Earth'
-    emoji: '648524067359686678'
-  - id: '692398773762261023'
-    desc: 'Minecraft: Dungeons'
-    emoji: '692399397232836758'
-  - id: '648536618113826847'
-    desc: Other projects
-    emoji: '648521149390520320'
+roleGroups:
+  - prompt: Please select the project(s) you are interested in, so that we can add you to the appropriate channels.
+    channelId: '648479533246316555'
+    messageId: '692405794305736816'
+    radio: false
+    roles:
+      - id: '648536573675044865'
+        desc: |-
+          Java Edition
+          _PC, Mac and Linux_
+        emoji: '648525192414494730'
+      - id: '648536590481752074'
+        desc: |-
+          Bedrock Edition
+          _Android, iOS, Windows 10, Xbox One, Nintendo Switch and Playstation 4_
+        emoji: '648474430158405642'
+      - id: '648536605094707201'
+        desc: 'Minecraft: Earth'
+        emoji: '648524067359686678'
+      - id: '692398773762261023'
+        desc: 'Minecraft: Dungeons'
+        emoji: '692399397232836758'
+      - id: '648536618113826847'
+        desc: Other projects
+        emoji: '648521149390520320'
+  - prompt: |-
+      Please select the pronoun(s) that you'd like to go by.
+      This is not mandatory, but we encourage people to use the appropriate pronouns when referring to each other.
+    channelId: '648479533246316555'
+    # messageId: ''
+    radio: false # Some people might go by multiple pronouns? So why I implemented the radio feature 😅
+    roles:
+      - id: '753741802829381765'
+        desc: He/Him
+        emoji: '🇭'
+      - id: '753741949474832434'
+        desc: She/Her
+        emoji: '🇸'
+      - id: '753742065971757167'
+        desc: They/Them
+        emoji: '🇹'
+      - id: '753745759148572801'
+        desc: |-
+          Other Pronoun
+          (please indicate in your nickname)
+        emoji: '🇴'
 
 filterFeeds:
   - jql: project = MC AND resolved > -1m AND resolution = Fixed AND fixVersion = earliestUnreleasedVersion()

--- a/config/main.yml
+++ b/config/main.yml
@@ -21,8 +21,8 @@ request:
 
 roleGroups:
   - prompt: Please select the project(s) you are interested in, so that we can add you to the appropriate channels.
-    channelId: '648479533246316555'
-    messageId: '692405794305736816'
+    channel: '648479533246316555'
+    message: '692405794305736816'
     radio: false
     roles:
       - id: '648536573675044865'
@@ -47,8 +47,8 @@ roleGroups:
   - prompt: |-
       Please select the pronoun(s) that you'd like to go by.
       This is not mandatory, but we encourage people to use the appropriate pronouns when referring to each other.
-    channelId: '648479533246316555'
-    # messageId: ''
+    channel: '648479533246316555'
+    # message: ''
     radio: false # Some people might go by multiple pronouns? So why I implemented the radio feature 😅
     roles:
       - id: '753741802829381765'

--- a/config/template.yml
+++ b/config/template.yml
@@ -17,12 +17,6 @@ owner: <string>
 # The channel ID of the bot's home channel.
 homeChannel: <string>
 
-# The channel ID of the bot's roles channel.
-rolesChannel: <string>
-
-# The message ID of the bot's roles message.
-rolesMessage: <string>
-
 # Whether the bot should send an embed when a full URL to a ticket gets posted.
 ticketUrlsCauseEmbed: <boolean>
 
@@ -105,20 +99,30 @@ request:
   # Optional; empty string by default
   responseMessage: <string>
 
-# A list of roles that should be used for the roles message
-roles:
-    # The role's ID
-  - id: <number>
+# A list of role groups that users can self-assign roles.
+roleGroups:
+  # A list of self-assignable roles for this group.
+  - roles:
+      # The role's ID
+    - id: <number>
 
-    # The role's description.
-    desc: <string>
+      # The role's description.
+      desc: <string>
 
-    # The ID of an emoji representing this role.
-    # This needs to be the ID of a custom emoji currently!
-    emoji: <number>
+      # The ID of an emoji representing this role.
+      # This needs to be the ID of a custom emoji currently!
+      emoji: <number>
 
-  - <see above>
-  - ...
+    - <see above>
+    - ...
+    # The prompt that should be shown for the role selection message.
+    prompt: <string>
+    # The channel ID of which the role selection message is in.
+    channelId: <string>
+    # The message ID of this role selection message.
+    messageId: <string>
+    # Whether or not users can only choose one role from this group.
+    radio: <boolean>
 
 # The interval of the check for filter feeds, in milliseconds.
 filterFeedInterval: <number>
@@ -149,7 +153,7 @@ filterFeeds:
 versionFeedInterval: <number>
 
 # A list of feeds that should be sent when there has been a change to a version.
-filterFeeds:
+versionFeeds:
     # The project whose versions should be monitored.
   - project: <string>
 

--- a/config/template.yml
+++ b/config/template.yml
@@ -118,9 +118,9 @@ roleGroups:
     # The prompt that should be shown for the role selection message.
     prompt: <string>
     # The channel ID of which the role selection message is in.
-    channelId: <string>
+    channel: <string>
     # The message ID of this role selection message.
-    messageId: <string>
+    message: <string>
     # Whether or not users can only choose one role from this group.
     radio: <boolean>
 

--- a/src/BotConfig.ts
+++ b/src/BotConfig.ts
@@ -60,8 +60,8 @@ export interface RoleConfig {
 export interface RoleGroupConfig {
 	roles: RoleConfig[];
 	prompt: string;
-	channelId: string;
-	messageId?: string;
+	channel: string;
+	message?: string;
 	radio?: boolean;
 }
 

--- a/src/BotConfig.ts
+++ b/src/BotConfig.ts
@@ -57,6 +57,14 @@ export interface RoleConfig {
 	id: string;
 }
 
+export interface RoleGroupConfig {
+	roles: RoleConfig[];
+	prompt: string;
+	channelId: string;
+	messageId?: string;
+	radio?: boolean;
+}
+
 export interface FilterFeedConfig {
 	jql: string;
 	channel: string;
@@ -82,8 +90,6 @@ export default class BotConfig {
 	public static owner: string;
 
 	public static homeChannel: string;
-	public static rolesChannel: string;
-	public static rolesMessage: string;
 
 	public static ticketUrlsCauseEmbed: boolean;
 	public static requiredTicketPrefix: string;
@@ -93,7 +99,7 @@ export default class BotConfig {
 
 	public static request: RequestConfig;
 
-	public static roles: RoleConfig[];
+	public static roleGroups: RoleGroupConfig[];
 
 	public static filterFeedInterval: number;
 	public static filterFeeds: FilterFeedConfig[];
@@ -109,8 +115,6 @@ export default class BotConfig {
 		this.owner = config.get( 'owner' );
 
 		this.homeChannel = config.get( 'homeChannel' );
-		this.rolesChannel = config.get( 'rolesChannel' );
-		this.rolesMessage = config.get( 'rolesMessage' );
 		this.ticketUrlsCauseEmbed = getOrDefault( 'ticketUrlsCauseEmbed', false );
 
 		this.forbiddenTicketPrefix = getOrDefault( 'forbiddenTicketPrefix', '' );
@@ -120,7 +124,7 @@ export default class BotConfig {
 
 		this.request = new RequestConfig();
 
-		this.roles = getOrDefault( 'roles', [] );
+		this.roleGroups = getOrDefault( 'roleGroups', [] );
 
 		this.filterFeedInterval = config.get( 'filterFeedInterval' );
 		this.filterFeeds = config.get( 'filterFeeds' );

--- a/src/MojiraBot.ts
+++ b/src/MojiraBot.ts
@@ -46,13 +46,13 @@ export default class MojiraBot {
 			EventRegistry.add( new ErrorEventHandler() );
 
 			for ( const group of BotConfig.roleGroups ) {
-				const channel = await DiscordUtil.getChannel( group.channelId );
+				const channel = await DiscordUtil.getChannel( group.channel );
 				if ( channel && channel instanceof TextChannel ) {
 					try {
-						if ( !group.messageId ) {
+						if ( !group.message ) {
 							RoleSelectionUtil.sendRoleSelectionMessage( channel, group );
 						}
-						await DiscordUtil.getMessage( channel, group.messageId );
+						await DiscordUtil.getMessage( channel, group.message );
 					} catch ( err ) {
 						this.logger.error( err );
 					}

--- a/src/MojiraBot.ts
+++ b/src/MojiraBot.ts
@@ -14,6 +14,7 @@ import FilterFeedTask from './tasks/FilterFeedTask';
 import TaskScheduler from './tasks/TaskScheduler';
 import VersionFeedTask from './tasks/VersionFeedTask';
 import DiscordUtil from './util/DiscordUtil';
+import { RoleSelectionUtil } from './util/RoleSelectionUtil';
 
 /**
  * Core class of MojiraBot
@@ -44,12 +45,17 @@ export default class MojiraBot {
 			EventRegistry.setClient( this.client );
 			EventRegistry.add( new ErrorEventHandler() );
 
-			const rolesChannel = await DiscordUtil.getChannel( BotConfig.rolesChannel );
-			if ( rolesChannel && rolesChannel instanceof TextChannel ) {
-				try {
-					await DiscordUtil.getMessage( rolesChannel, BotConfig.rolesMessage );
-				} catch ( err ) {
-					this.logger.error( err );
+			for ( const group of BotConfig.roleGroups ) {
+				const channel = await DiscordUtil.getChannel( group.channelId );
+				if ( channel && channel instanceof TextChannel ) {
+					try {
+						if ( !group.messageId ) {
+							RoleSelectionUtil.sendRoleSelectionMessage( channel, group );
+						}
+						await DiscordUtil.getMessage( channel, group.messageId );
+					} catch ( err ) {
+						this.logger.error( err );
+					}
 				}
 			}
 

--- a/src/events/reaction/ReactionAddEventHandler.ts
+++ b/src/events/reaction/ReactionAddEventHandler.ts
@@ -31,7 +31,7 @@ export default class ReactionAddEventHandler implements DiscordEventHandler<'mes
 			await messageReaction.fetch();
 		}
 
-		if ( BotConfig.roleGroups.find( g => g.messageId === messageReaction.message.id ) ) {
+		if ( BotConfig.roleGroups.find( g => g.message === messageReaction.message.id ) ) {
 			// Handle role selection
 			return this.roleSelectHandler.onEvent( messageReaction, user );
 		} else if ( BotConfig.request.internalChannels.includes( messageReaction.message.channel.id ) ) {

--- a/src/events/reaction/ReactionAddEventHandler.ts
+++ b/src/events/reaction/ReactionAddEventHandler.ts
@@ -31,7 +31,7 @@ export default class ReactionAddEventHandler implements DiscordEventHandler<'mes
 			await messageReaction.fetch();
 		}
 
-		if ( messageReaction.message.id === BotConfig.rolesMessage ) {
+		if ( BotConfig.roleGroups.find( g => g.messageId === messageReaction.message.id ) ) {
 			// Handle role selection
 			return this.roleSelectHandler.onEvent( messageReaction, user );
 		} else if ( BotConfig.request.internalChannels.includes( messageReaction.message.channel.id ) ) {

--- a/src/events/reaction/ReactionRemoveEventHandler.ts
+++ b/src/events/reaction/ReactionRemoveEventHandler.ts
@@ -24,7 +24,7 @@ export default class ReactionRemoveEventHandler implements EventHandler<'message
 			await messageReaction.fetch();
 		}
 
-		if ( BotConfig.roleGroups.find( g => g.messageId === messageReaction.message.id ) ) {
+		if ( BotConfig.roleGroups.find( g => g.message === messageReaction.message.id ) ) {
 			// Handle role removal
 			return this.roleRemoveHandler.onEvent( messageReaction, user );
 		} else if ( BotConfig.request.internalChannels.includes( messageReaction.message.channel.id ) ) {

--- a/src/events/reaction/ReactionRemoveEventHandler.ts
+++ b/src/events/reaction/ReactionRemoveEventHandler.ts
@@ -24,7 +24,7 @@ export default class ReactionRemoveEventHandler implements EventHandler<'message
 			await messageReaction.fetch();
 		}
 
-		if ( messageReaction.message.id === BotConfig.rolesMessage ) {
+		if ( BotConfig.roleGroups.find( g => g.messageId === messageReaction.message.id ) ) {
 			// Handle role removal
 			return this.roleRemoveHandler.onEvent( messageReaction, user );
 		} else if ( BotConfig.request.internalChannels.includes( messageReaction.message.channel.id ) ) {

--- a/src/events/roles/RoleRemoveEventHandler.ts
+++ b/src/events/roles/RoleRemoveEventHandler.ts
@@ -13,7 +13,8 @@ export default class RoleRemoveEventHandler implements EventHandler<'messageReac
 	public onEvent = async ( messageReaction: MessageReaction, user: User ): Promise<void> => {
 		this.logger.info( `User ${ user.tag } removed '${ messageReaction.emoji.name }' reaction from role message` );
 
-		const role = BotConfig.roles.find( searchedRole => searchedRole.emoji === messageReaction.emoji.id );
+		const group = BotConfig.roleGroups.find( searchedGroup => searchedGroup.messageId === messageReaction.message.id );
+		const role = group.roles.find( searchedRole => searchedRole.emoji === messageReaction.emoji.id );
 
 		if ( !role ) return;
 

--- a/src/events/roles/RoleRemoveEventHandler.ts
+++ b/src/events/roles/RoleRemoveEventHandler.ts
@@ -14,7 +14,7 @@ export default class RoleRemoveEventHandler implements EventHandler<'messageReac
 		this.logger.info( `User ${ user.tag } removed '${ messageReaction.emoji.name }' reaction from role message` );
 
 		const group = BotConfig.roleGroups.find( searchedGroup => searchedGroup.message === messageReaction.message.id );
-		const role = group.roles.find( searchedRole => searchedRole.emoji === messageReaction.emoji.id );
+		const role = group.roles.find( searchedRole => searchedRole.emoji === messageReaction.emoji.id || searchedRole.emoji === messageReaction.emoji.name );
 
 		if ( !role ) return;
 

--- a/src/events/roles/RoleRemoveEventHandler.ts
+++ b/src/events/roles/RoleRemoveEventHandler.ts
@@ -13,7 +13,7 @@ export default class RoleRemoveEventHandler implements EventHandler<'messageReac
 	public onEvent = async ( messageReaction: MessageReaction, user: User ): Promise<void> => {
 		this.logger.info( `User ${ user.tag } removed '${ messageReaction.emoji.name }' reaction from role message` );
 
-		const group = BotConfig.roleGroups.find( searchedGroup => searchedGroup.messageId === messageReaction.message.id );
+		const group = BotConfig.roleGroups.find( searchedGroup => searchedGroup.message === messageReaction.message.id );
 		const role = group.roles.find( searchedRole => searchedRole.emoji === messageReaction.emoji.id );
 
 		if ( !role ) return;

--- a/src/events/roles/RoleSelectEventHandler.ts
+++ b/src/events/roles/RoleSelectEventHandler.ts
@@ -14,7 +14,7 @@ export default class RoleSelectEventHandler implements EventHandler<'messageReac
 		this.logger.info( `User ${ user.tag } added '${ messageReaction.emoji.name }' reaction to role message` );
 
 		const group = BotConfig.roleGroups.find( searchedGroup => searchedGroup.message === messageReaction.message.id );
-		const role = group.roles.find( searchedRole => searchedRole.emoji === messageReaction.emoji.id );
+		const role = group.roles.find( searchedRole => searchedRole.emoji === messageReaction.emoji.id || searchedRole.emoji === messageReaction.emoji.name );
 
 		if ( !role ) {
 			messageReaction.users.remove( user );

--- a/src/events/roles/RoleSelectEventHandler.ts
+++ b/src/events/roles/RoleSelectEventHandler.ts
@@ -13,7 +13,7 @@ export default class RoleSelectEventHandler implements EventHandler<'messageReac
 	public onEvent = async ( messageReaction: MessageReaction, user: User ): Promise<void> => {
 		this.logger.info( `User ${ user.tag } added '${ messageReaction.emoji.name }' reaction to role message` );
 
-		const group = BotConfig.roleGroups.find( searchedGroup => searchedGroup.messageId === messageReaction.message.id );
+		const group = BotConfig.roleGroups.find( searchedGroup => searchedGroup.message === messageReaction.message.id );
 		const role = group.roles.find( searchedRole => searchedRole.emoji === messageReaction.emoji.id );
 
 		if ( !role ) {

--- a/src/mentions/SingleMention.ts
+++ b/src/mentions/SingleMention.ts
@@ -99,6 +99,7 @@ export class SingleMention extends Mention {
 			.addField( 'Status', status, !largeStatus )
 			.setColor( 'RED' );
 
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		function findThumbnail( attachments: any[] ): string {
 			const allowedMimes = [
 				'image/png', 'image/jpeg',

--- a/src/util/RoleSelectionUtil.ts
+++ b/src/util/RoleSelectionUtil.ts
@@ -14,7 +14,7 @@ export class RoleSelectionUtil {
 			.setColor( 'AQUA' );
 		for ( const role of groupConfig.roles ) {
 			const roleEmoji = MojiraBot.client.emojis.cache.get( role.emoji );
-			const textEmoji = ( roleEmoji == undefined ) ? '❓' : roleEmoji.toString();
+			const textEmoji = ( roleEmoji == undefined ) ? role.emoji : roleEmoji.toString();
 			embed.addField( textEmoji, role.desc );
 		}
 		let sentMessage: Message | Message[];

--- a/src/util/RoleSelectionUtil.ts
+++ b/src/util/RoleSelectionUtil.ts
@@ -1,0 +1,40 @@
+import * as log4js from 'log4js';
+import { Message, MessageEmbed, TextChannel } from 'discord.js';
+import { RoleGroupConfig } from '../BotConfig';
+import MojiraBot from '../MojiraBot';
+import { ReactionsUtil } from './ReactionsUtil';
+
+export class RoleSelectionUtil {
+	private static logger = log4js.getLogger( 'RoleSelectionUtil' );
+
+	public static async sendRoleSelectionMessage( channel: TextChannel, groupConfig: RoleGroupConfig ): Promise<void> {
+		const embed = new MessageEmbed();
+		embed
+			.setTitle( groupConfig.prompt )
+			.setColor( 'AQUA' );
+		for ( const role of groupConfig.roles ) {
+			const roleEmoji = MojiraBot.client.emojis.cache.get( role.emoji );
+			const textEmoji = ( roleEmoji == undefined ) ? '❓' : roleEmoji.toString();
+			embed.addField( textEmoji, role.desc );
+		}
+		let sentMessage: Message | Message[];
+		try {
+			sentMessage = await channel.send( embed );
+		} catch ( err ) {
+			this.logger.error( err );
+			return;
+		}
+		if ( sentMessage instanceof Array ) {
+			if ( sentMessage.length !== 1 ) {
+				this.logger.error( 'Result of sending role selection message was not exactly one message' );
+				return;
+			} else {
+				sentMessage = sentMessage[0];
+			}
+		}
+		ReactionsUtil.reactToMessage( sentMessage as Message, groupConfig.roles.map( role => role.emoji ) );
+
+		// TODO: Ideally we would like to save the message ID automagically.
+		this.logger.warn( `Please set the 'messageId' for role selection group '${ groupConfig.prompt }' to '${ ( sentMessage as Message ).id }' in the config.` );
+	}
+}

--- a/src/util/RoleSelectionUtil.ts
+++ b/src/util/RoleSelectionUtil.ts
@@ -35,6 +35,6 @@ export class RoleSelectionUtil {
 		ReactionsUtil.reactToMessage( sentMessage as Message, groupConfig.roles.map( role => role.emoji ) );
 
 		// TODO: Ideally we would like to save the message ID automagically.
-		this.logger.warn( `Please set the 'messageId' for role selection group '${ groupConfig.prompt }' to '${ ( sentMessage as Message ).id }' in the config.` );
+		this.logger.warn( `Please set the 'message' for role selection group '${ groupConfig.prompt }' to '${ ( sentMessage as Message ).id }' in the config.` );
 	}
 }


### PR DESCRIPTION
## Purpose
Allow multiple role selection groups. And added a new role group for pronouns.

## Approach

## Future work
After merging this PR, the bot would send a message in the current `#role-selection` channel automagically. We would want to save the message ID of that message to the config's `message` field, so that the bot can find that message after restart.

This isn't ideal, but I'm just too lazy to implement the auto-saving-config feature.