### PR TITLE
Fix version log and catch promise errors properly

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,8 @@
 		"node": true
 	},
 	"parserOptions": {
-		"sourceType": "module"
+		"sourceType": "module",
+		"project": "tsconfig.json"
 	},
 	"rules": {
 		"brace-style": ["error", "1tbs", { "allowSingleLine": true }],
@@ -26,6 +27,7 @@
 		"max-statements-per-line": ["error", { "max": 2 }],
 		"no-empty-function": "error",
 		"no-floating-decimal": "error",
+		"@typescript-eslint/no-floating-promises": "error",
 		"no-inline-comments": "error",
 		"no-lonely-if": "error",
 		"no-multi-spaces": "error",

--- a/config/template.yml
+++ b/config/template.yml
@@ -139,7 +139,7 @@ filterFeeds:
     # {{num}} will be replaced by the number of ticket(s).
     title: <string>
     
-    # The emoji to react to all filter feed messages with.
+    # Optional; The emoji to react to all filter feed messages with.
     filterFeedEmoji: <string>
     
     # The message accompanying this feed embed, in case there's only one ticket.
@@ -163,7 +163,7 @@ versionFeeds:
     # The interval of the check for this version feed, in milliseconds.
     interval: <number>
 
-    # The emoji to react to all version feed messages with.
+    # Optional; The emoji to react to all version feed messages with.
     versionFeedEmoji: <string>
 
     # How many versions should be monitored; only the x latest versions are monitored.

--- a/src/MojiraBot.ts
+++ b/src/MojiraBot.ts
@@ -50,7 +50,11 @@ export default class MojiraBot {
 				if ( channel && channel instanceof TextChannel ) {
 					try {
 						if ( !group.message ) {
-							RoleSelectionUtil.sendRoleSelectionMessage( channel, group );
+							try {
+								await RoleSelectionUtil.sendRoleSelectionMessage( channel, group );
+							} catch ( error ) {
+								MojiraBot.logger.error( error );
+							}
 						}
 						await DiscordUtil.getMessage( channel, group.message );
 					} catch ( err ) {
@@ -97,7 +101,11 @@ export default class MojiraBot {
 									const users = await reaction.users.fetch();
 									const user = users.array().find( v => v.id !== this.client.user.id );
 									if ( user ) {
-										handler.onEvent( reaction, user );
+										try {
+											await handler.onEvent( reaction, user );
+										} catch ( error ) {
+											MojiraBot.logger.error( error );
+										}
 									}
 								} );
 							}
@@ -114,7 +122,12 @@ export default class MojiraBot {
 						const options: ChannelLogsQueryOptions = { limit: 1, before: lastId };
 						const message = ( await requestChannel.messages.fetch( options ) ).first();
 						if ( message?.reactions?.cache.size === 0 ) {
-							newRequestHandler.onEvent( message );
+							try {
+								await newRequestHandler.onEvent( message );
+							} catch ( error ) {
+								MojiraBot.logger.error( error );
+							}
+
 							lastId = message.id;
 						} else {
 							break;
@@ -148,7 +161,11 @@ export default class MojiraBot {
 			// #endregion
 
 			// TODO Change to custom status when discord.js#3552 is merged into current version of package
-			this.client.user.setActivity( '!jira help' );
+			try {
+				await this.client.user.setActivity( '!jira help' );
+			} catch ( error ) {
+				MojiraBot.logger.error( error );
+			}
 
 			const homeChannel = await DiscordUtil.getChannel( BotConfig.homeChannel );
 

--- a/src/commands/BugCommand.ts
+++ b/src/commands/BugCommand.ts
@@ -15,7 +15,7 @@ export default class BugCommand extends PrefixCommand {
 		for ( const ticket of tickets ) {
 			if ( !ticketRegex.test( ticket ) ) {
 				try {
-					message.channel.send( `'${ ticket }' is not a valid ticket ID.` );
+					await message.channel.send( `'${ ticket }' is not a valid ticket ID.` );
 				} catch ( err ) {
 					Command.logger.log( err );
 				}
@@ -30,7 +30,7 @@ export default class BugCommand extends PrefixCommand {
 			embed = await mention.getEmbed();
 		} catch ( err ) {
 			try {
-				message.channel.send( err );
+				await message.channel.send( err );
 			} catch ( err ) {
 				Command.logger.log( err );
 			}
@@ -56,7 +56,7 @@ export default class BugCommand extends PrefixCommand {
 				Command.logger.error( err );
 			}
 		} else {
-			console.log( 'message not deletable' );
+			BugCommand.logger.log( 'message not deletable' );
 		}
 
 		return true;

--- a/src/commands/MentionCommand.ts
+++ b/src/commands/MentionCommand.ts
@@ -45,7 +45,7 @@ export default class MentionCommand extends Command {
 			embed = await mention.getEmbed();
 		} catch ( err ) {
 			try {
-				message.channel.send( err );
+				await message.channel.send( err );
 			} catch ( err ) {
 				Command.logger.log( err );
 			}
@@ -70,7 +70,7 @@ export default class MentionCommand extends Command {
 
 			if ( matchesTicketId || ( BotConfig.ticketUrlsCauseEmbed && matchesTicketUrl ) ) {
 				try {
-					message.delete();
+					await message.delete();
 				} catch ( err ) {
 					Command.logger.error( err );
 				}

--- a/src/commands/PollCommand.ts
+++ b/src/commands/PollCommand.ts
@@ -140,7 +140,7 @@ export default class PollCommand extends PrefixCommand {
 			}
 		}
 
-		this.sendPollMessage( message, pollTitle, options );
+		await this.sendPollMessage( message, pollTitle, options );
 
 		return true;
 	}

--- a/src/commands/RolesCommand.ts
+++ b/src/commands/RolesCommand.ts
@@ -8,7 +8,7 @@ export default class RolesCommand extends PrefixCommand {
 	public readonly aliases = ['roles'];
 
 	private async sendRolesMessage( channel: TextChannel | DMChannel | NewsChannel ): Promise<boolean> {
-		channel.send( 'Sorry, this command is currently disabled!' );
+		await channel.send( 'Sorry, this command is currently disabled!' );
 
 		// const embed = new MessageEmbed();
 		// embed.setTitle( 'Please select the project(s) you are interested in, so that we can add you to the appropriate channels.' )
@@ -48,7 +48,7 @@ export default class RolesCommand extends PrefixCommand {
 			return false;
 		}
 
-		this.sendRolesMessage( message.channel );
+		await this.sendRolesMessage( message.channel );
 
 		// if ( message.deletable ) {
 		// 	try {

--- a/src/events/EventHandler.ts
+++ b/src/events/EventHandler.ts
@@ -8,5 +8,5 @@ import { ClientEvents } from 'discord.js';
  */
 export default interface EventHandler<K extends keyof ClientEvents> {
 	eventName: K;
-	onEvent: ( ...args: ClientEvents[K] ) => void;
+	onEvent: ( ...args: ClientEvents[K] ) => void | Promise<void>;
 }

--- a/src/events/message/MessageDeleteEventHandler.ts
+++ b/src/events/message/MessageDeleteEventHandler.ts
@@ -17,7 +17,7 @@ export default class MessageDeleteEventHandler implements EventHandler<'messageD
 	}
 
 	// This syntax is used to ensure that `this` refers to the `MessageDeleteEventHandler` object
-	public onEvent = ( message: Message ): void => {
+	public onEvent = async ( message: Message ): Promise<void> => {
 		if (
 			// Don't handle non-default messages
 			message.type !== 'DEFAULT'
@@ -31,7 +31,7 @@ export default class MessageDeleteEventHandler implements EventHandler<'messageD
 
 		if ( BotConfig.request.channels && BotConfig.request.channels.includes( message.channel.id ) ) {
 			// The deleted message is in a request channel
-			this.requestDeleteEventHandler.onEvent( message );
+			await this.requestDeleteEventHandler.onEvent( message );
 		}
 	};
 }

--- a/src/events/message/MessageEventHandler.ts
+++ b/src/events/message/MessageEventHandler.ts
@@ -18,7 +18,7 @@ export default class MessageEventHandler implements EventHandler<'message'> {
 	}
 
 	// This syntax is used to ensure that `this` refers to the `MessageEventHandler` object
-	public onEvent = ( message: Message ): void => {
+	public onEvent = async ( message: Message ): Promise<void> => {
 		if (
 			// Don't reply to webhooks
 			message.webhookID
@@ -32,12 +32,12 @@ export default class MessageEventHandler implements EventHandler<'message'> {
 
 		if ( BotConfig.request.channels && BotConfig.request.channels.includes( message.channel.id ) ) {
 			// This message is in a request channel
-			this.requestEventHandler.onEvent( message );
+			await this.requestEventHandler.onEvent( message );
 
 			// Don't reply in request channels
 			return;
 		}
 
-		CommandExecutor.checkCommands( message );
+		await CommandExecutor.checkCommands( message );
 	};
 }

--- a/src/events/message/MessageUpdateEventHandler.ts
+++ b/src/events/message/MessageUpdateEventHandler.ts
@@ -20,7 +20,7 @@ export default class MessageUpdateEventHandler implements EventHandler<'messageU
 	}
 
 	// This syntax is used to ensure that `this` refers to the `MessageUpdateEventHandler` object
-	public onEvent = ( oldMessage: Message, newMessage: Message ): void => {
+	public onEvent = async ( oldMessage: Message, newMessage: Message ): Promise<void> => {
 		if (
 			// Don't handle non-default messages
 			oldMessage.type !== 'DEFAULT'
@@ -34,8 +34,8 @@ export default class MessageUpdateEventHandler implements EventHandler<'messageU
 
 		if ( BotConfig.request.channels && BotConfig.request.channels.includes( oldMessage.channel.id ) ) {
 			// The updated message is in a request channel
-			this.requestDeleteEventHandler.onEvent( oldMessage );
-			this.requestEventHandler.onEvent( newMessage );
+			await this.requestDeleteEventHandler.onEvent( oldMessage );
+			await this.requestEventHandler.onEvent( newMessage );
 		}
 	};
 }

--- a/src/events/request/RequestDeleteEventHandler.ts
+++ b/src/events/request/RequestDeleteEventHandler.ts
@@ -35,7 +35,11 @@ export default class RequestDeleteEventHandler implements EventHandler<'messageD
 				if ( result.channelId === origin.channel.id && result.messageId === origin.id ) {
 					TaskScheduler.clearMessageTasks( internalMessage );
 					if ( internalMessage.deletable ) {
-						internalMessage.delete();
+						try {
+							await internalMessage.delete();
+						} catch ( error ) {
+							this.logger.error( error );
+						}
 					}
 				}
 			}

--- a/src/events/request/RequestEventHandler.ts
+++ b/src/events/request/RequestEventHandler.ts
@@ -29,7 +29,11 @@ export default class RequestEventHandler implements EventHandler<'message'> {
 
 		this.logger.info( `User ${ origin.author.tag } posted a new request to requests channel ${ origin.channel.id }` );
 
-		await origin.reactions.removeAll();
+		try {
+			await origin.reactions.removeAll();
+		} catch ( error ) {
+			this.logger.error( error );
+		}
 
 		const regex = new RegExp( `(?:${ MentionCommand.ticketLinkRegex.source }|(${ MentionCommand.ticketPattern }))(\\?\\S+)?`, 'g' );
 

--- a/src/events/request/RequestReopenEventHandler.ts
+++ b/src/events/request/RequestReopenEventHandler.ts
@@ -1,4 +1,4 @@
-import { Message, MessageEmbed, MessageReaction, TextChannel, User } from 'discord.js';
+import { MessageEmbed, MessageReaction, TextChannel, User } from 'discord.js';
 import * as log4js from 'log4js';
 import BotConfig from '../../BotConfig';
 import DiscordUtil from '../../util/DiscordUtil';
@@ -22,9 +22,14 @@ export default class RequestReopenEventHandler implements EventHandler<'messageR
 
 		const embeds = message.embeds;
 		if ( embeds.length == 0 ) {
-			const timeout = BotConfig.request.noLinkWarningLifetime;
-			const warning = await message.channel.send( `${ message.author }, this is not a valid log message.` ) as Message;
-			warning.delete( { timeout } );
+			try {
+				const warning = await message.channel.send( `${ message.author }, this is not a valid log message.` );
+
+				const timeout = BotConfig.request.noLinkWarningLifetime;
+				await warning.delete( { timeout } );
+			} catch ( error ) {
+				this.logger.error( error );
+			}
 		}
 
 		// Assume first embed is the log message
@@ -47,7 +52,12 @@ export default class RequestReopenEventHandler implements EventHandler<'messageR
 					.addField( 'Message', `[Here](${ requestMessage.url })`, true )
 					.setFooter( `${ user.tag } reopened this request`, user.avatarURL() )
 					.setTimestamp( new Date() );
-				logChannel.send( log );
+
+				try {
+					await logChannel.send( log );
+				} catch ( error ) {
+					this.logger.error( error );
+				}
 			}
 
 			await this.requestEventHandler.onEvent( requestMessage );

--- a/src/events/request/RequestResolveEventHandler.ts
+++ b/src/events/request/RequestResolveEventHandler.ts
@@ -21,7 +21,11 @@ export default class RequestResolveEventHandler implements EventHandler<'message
 			&& BotConfig.request.ignorePrependResponseMessageEmoji !== reaction.emoji.name ) {
 			const origin = await RequestsUtil.getOriginMessage( reaction.message );
 			if ( origin ) {
-				reaction.message.edit( RequestsUtil.getResponseMessage( origin ) );
+				try {
+					await reaction.message.edit( RequestsUtil.getResponseMessage( origin ) );
+				} catch ( error ) {
+					this.logger.error( error );
+				}
 			}
 		}
 

--- a/src/events/request/RequestUnresolveEventHandler.ts
+++ b/src/events/request/RequestUnresolveEventHandler.ts
@@ -10,11 +10,15 @@ export default class RequestUnresolveEventHandler implements EventHandler<'messa
 	private logger = log4js.getLogger( 'RequestUnresolveEventHandler' );
 
 	// This syntax is used to ensure that `this` refers to the `RequestUnresolveEventHandler` object
-	public onEvent = ( { emoji, message }: MessageReaction, user: User ): void => {
+	public onEvent = async ( { emoji, message }: MessageReaction, user: User ): Promise<void> => {
 		this.logger.info( `User ${ user.tag } removed '${ emoji.name }' reaction from request message '${ message.id }'` );
 
 		if ( BotConfig.request.prependResponseMessage == PrependResponseMessageType.WhenResolved ) {
-			message.edit( '' );
+			try {
+				await message.edit( '' );
+			} catch ( error ) {
+				this.logger.error( error );
+			}
 		}
 
 		if ( message.reactions.cache.size <= BotConfig.request.suggestedEmoji.length ) {

--- a/src/events/roles/RoleRemoveEventHandler.ts
+++ b/src/events/roles/RoleRemoveEventHandler.ts
@@ -20,7 +20,11 @@ export default class RoleRemoveEventHandler implements EventHandler<'messageReac
 
 		const member = await DiscordUtil.getMember( messageReaction.message.guild, user.id );
 		if ( member ) {
-			member.roles.remove( role.id );
+			try {
+				await member.roles.remove( role.id );
+			} catch ( error ) {
+				this.logger.error( error );
+			}
 		}
 	};
 }

--- a/src/events/roles/RoleSelectEventHandler.ts
+++ b/src/events/roles/RoleSelectEventHandler.ts
@@ -17,7 +17,11 @@ export default class RoleSelectEventHandler implements EventHandler<'messageReac
 		const role = group.roles.find( searchedRole => searchedRole.emoji === messageReaction.emoji.id || searchedRole.emoji === messageReaction.emoji.name );
 
 		if ( !role ) {
-			await messageReaction.users.remove( user );
+			try {
+				await messageReaction.users.remove( user );
+			} catch ( error ) {
+				this.logger.error( error );
+			}
 			return;
 		}
 

--- a/src/events/roles/RoleSelectEventHandler.ts
+++ b/src/events/roles/RoleSelectEventHandler.ts
@@ -17,7 +17,7 @@ export default class RoleSelectEventHandler implements EventHandler<'messageReac
 		const role = group.roles.find( searchedRole => searchedRole.emoji === messageReaction.emoji.id || searchedRole.emoji === messageReaction.emoji.name );
 
 		if ( !role ) {
-			messageReaction.users.remove( user );
+			await messageReaction.users.remove( user );
 			return;
 		}
 
@@ -27,19 +27,31 @@ export default class RoleSelectEventHandler implements EventHandler<'messageReac
 			// Remove other reactions.
 			for ( const reaction of messageReaction.message.reactions.cache.values() ) {
 				if ( reaction.emoji.id !== role.emoji ) {
-					reaction.remove();
+					try {
+						await reaction.remove();
+					} catch ( error ) {
+						this.logger.error( error );
+					}
 				}
 			}
 			// Remove other roles.
 			if ( member ) {
 				for ( const { id } of group.roles ) {
-					member.roles.remove( id );
+					try {
+						await member.roles.remove( id );
+					} catch ( error ) {
+						this.logger.error( error );
+					}
 				}
 			}
 		}
 
 		if ( member ) {
-			member.roles.add( role.id );
+			try {
+				await member.roles.add( role.id );
+			} catch ( error ) {
+				this.logger.error( error );
+			}
 		}
 	};
 }

--- a/src/tasks/FilterFeedTask.ts
+++ b/src/tasks/FilterFeedTask.ts
@@ -77,10 +77,12 @@ export default class FilterFeedTask extends Task {
 
 						await NewsUtil.publishMessage( filterFeedMessage );
 
-						try {
-							await filterFeedMessage.react( this.filterFeedEmoji );
-						} catch ( error ) {
-							FilterFeedTask.logger.error( error );
+						if ( this.filterFeedEmoji !== undefined ) {
+							try {
+								await filterFeedMessage.react( this.filterFeedEmoji );
+							} catch ( error ) {
+								FilterFeedTask.logger.error( error );
+							}
 						}
 					} else {
 						throw new Error( `Expected ${ this.channel } to be a TextChannel` );

--- a/src/tasks/FilterFeedTask.ts
+++ b/src/tasks/FilterFeedTask.ts
@@ -7,7 +7,7 @@ import JiraClient from 'jira-connector';
 import { NewsUtil } from '../util/NewsUtil';
 
 export default class FilterFeedTask extends Task {
-	public static logger = log4js.getLogger( 'FilterFeed' );
+	private static logger = log4js.getLogger( 'FilterFeedTask' );
 
 	private jira: JiraClient;
 	private channel: Channel;
@@ -32,7 +32,7 @@ export default class FilterFeedTask extends Task {
 			strictSSL: true,
 		} );
 
-		this.run();
+		this.run().catch( FilterFeedTask.logger.error );
 	}
 
 	public async run(): Promise<void> {
@@ -74,8 +74,14 @@ export default class FilterFeedTask extends Task {
 
 					if ( this.channel instanceof TextChannel ) {
 						const filterFeedMessage = await this.channel.send( message, embed );
-						NewsUtil.publishMessage( filterFeedMessage );
-						filterFeedMessage.react( this.filterFeedEmoji );
+
+						await NewsUtil.publishMessage( filterFeedMessage );
+
+						try {
+							await filterFeedMessage.react( this.filterFeedEmoji );
+						} catch ( error ) {
+							FilterFeedTask.logger.error( error );
+						}
 					} else {
 						throw new Error( `Expected ${ this.channel } to be a TextChannel` );
 					}

--- a/src/tasks/VersionFeedTask.ts
+++ b/src/tasks/VersionFeedTask.ts
@@ -79,10 +79,12 @@ export default class VersionFeedTask extends Task {
 
 			await NewsUtil.publishMessage( versionFeedMessage );
 
-			try {
-				await versionFeedMessage.react( this.versionFeedEmoji );
-			} catch ( error ) {
-				VersionFeedTask.logger.error( error );
+			if ( this.versionFeedEmoji !== undefined ) {
+				try {
+					await versionFeedMessage.react( this.versionFeedEmoji );
+				} catch ( error ) {
+					VersionFeedTask.logger.error( error );
+				}
 			}
 		}
 

--- a/src/util/ReactionsUtil.ts
+++ b/src/util/ReactionsUtil.ts
@@ -12,6 +12,7 @@ export class ReactionsUtil {
 		} catch ( err ) {
 			this.logger.error( err );
 		}
-		this.reactToMessage( message, reactions );
+
+		await this.reactToMessage( message, reactions );
 	}
 }

--- a/src/util/RoleSelectionUtil.ts
+++ b/src/util/RoleSelectionUtil.ts
@@ -32,7 +32,13 @@ export class RoleSelectionUtil {
 				sentMessage = sentMessage[0];
 			}
 		}
-		ReactionsUtil.reactToMessage( sentMessage as Message, groupConfig.roles.map( role => role.emoji ) );
+
+		try {
+			await ReactionsUtil.reactToMessage( sentMessage as Message, groupConfig.roles.map( role => role.emoji ) );
+		} catch ( error ) {
+			this.logger.error( error );
+			return;
+		}
 
 		// TODO: Ideally we would like to save the message ID automagically.
 		this.logger.warn( `Please set the 'message' for role selection group '${ groupConfig.prompt }' to '${ ( sentMessage as Message ).id }' in the config.` );


### PR DESCRIPTION
## Purpose
This fixes the bot spamming `#version-log` with supposed version changes indefinitely.

## Approach
This makes feed reactions optional, meaning that they can be omitted from the config. Previously the reactions were not optional for feeds and if they were not defined, the bot would get stuck in a loop.

Additionally, for better error reporting, all promises are now properly handled with `await` and `try`/`catch` where necessary.

## Future work
Improve the config further so that "sub-configs" like the filter config are type-safe as well.