### PR TITLE
Make Owner permission available to multiple users

### DIFF
--- a/config/beta.yml
+++ b/config/beta.yml
@@ -2,7 +2,8 @@
 
 debug: true
 
-owner: '417403221863301130'
+owners:
+  - '417403221863301130' # violine1101
 
 homeChannel: '649027251010142228'
 

--- a/config/main.yml
+++ b/config/main.yml
@@ -1,6 +1,12 @@
 # Settings for the offical Mojira Discord bot
 
-owner: '417403221863301130'
+owners:
+  - '87225001874325504' # urielsalis
+  - '137290216691073024' # NeunEinser
+  - '252267207264960513' # LateLag
+  - '263098499858563072' # Sonicwave
+  - '417403221863301130' # violine1101
+  - '437088929485684737' # SPGoding
 
 homeChannel: '646317855234850818'
 

--- a/config/template.yml
+++ b/config/template.yml
@@ -11,8 +11,12 @@ logDirectory: <string | false>
 # Your bot token used to log in to Discord with the bot.
 token: <string>
 
-# Your user ID for owner only commands.
-owner: <string>
+# A list of user IDs for owner only commands.
+# Optional; empty by default.
+owners:
+  - <string>
+  - <string>
+  - ...
 
 # The channel ID of the bot's home channel.
 homeChannel: <string>
@@ -139,7 +143,8 @@ filterFeeds:
     # {{num}} will be replaced by the number of ticket(s).
     title: <string>
     
-    # Optional; The emoji to react to all filter feed messages with.
+    # The emoji to react to all filter feed messages with.
+    # Optional; none by default.
     filterFeedEmoji: <string>
     
     # The message accompanying this feed embed, in case there's only one ticket.
@@ -163,7 +168,8 @@ versionFeeds:
     # The interval of the check for this version feed, in milliseconds.
     interval: <number>
 
-    # Optional; The emoji to react to all version feed messages with.
+    # The emoji to react to all version feed messages with.
+    # Optional; none by default.
     versionFeedEmoji: <string>
 
     # How many versions should be monitored; only the x latest versions are monitored.

--- a/src/BotConfig.ts
+++ b/src/BotConfig.ts
@@ -89,7 +89,7 @@ export default class BotConfig {
 
 	// TODO: make private again when /crosspost api endpoint is implemented into discord.js
 	public static token: string;
-	public static owner: string;
+	public static owners: string[];
 
 	public static homeChannel: string;
 
@@ -111,7 +111,7 @@ export default class BotConfig {
 		this.logDirectory = getOrDefault( 'logDirectory', false );
 
 		this.token = config.get( 'token' );
-		this.owner = config.get( 'owner' );
+		this.owners = getOrDefault( 'owners', [] );
 
 		this.homeChannel = config.get( 'homeChannel' );
 		this.ticketUrlsCauseEmbed = getOrDefault( 'ticketUrlsCauseEmbed', false );

--- a/src/permissions/OwnerPermission.ts
+++ b/src/permissions/OwnerPermission.ts
@@ -4,6 +4,6 @@ import BotConfig from '../BotConfig';
 
 export default class OwnerPermission extends Permission {
 	public checkPermission( member?: GuildMember ): boolean {
-		return member?.id === BotConfig.owner;
+		return BotConfig.owners.includes( member?.id );
 	}
 }


### PR DESCRIPTION
## Purpose
Fix #116 and give some users owner permission so that they can use `!jira stop` in an emergency.

## Approach
Change config `owner` to a list of strings called `owners` and check if the user's id is in that list.

## Future work
Add more distinct permission levels for more granular control, and if possible, link it to Discord roles. Also, add a restart command that restarts the bot instead of just stopping it.