### PR TITLE
Show fixed tickets from any future version

### DIFF
--- a/config/main.yml
+++ b/config/main.yml
@@ -73,7 +73,7 @@ roleGroups:
         emoji: '🇴'
 
 filterFeeds:
-  - jql: project = MC AND resolved > -1m AND resolution = Fixed AND fixVersion = earliestUnreleasedVersion()
+  - jql: project = MC AND resolved > -1m AND resolution = Fixed AND fixVersion in unreleasedVersions()
     channel: '666349583227682819'
     interval: 30000
     filterFeedEmoji: '🎉'


### PR DESCRIPTION
## Purpose
Currently, the `#java-fixes` feed only shows tickets from the earliest unreleased version. It should show tickets from any unreleased version.

## Approach
Use JQL `fixVersion in unreleasedVersions()`

## Future work
N/A