### PR TITLE
Fix backtracking requests

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -43,5 +43,4 @@ request:
     {{author}} {{url}}
     {{message}}
     
-    <Enter your response here>
     ```

--- a/src/MojiraBot.ts
+++ b/src/MojiraBot.ts
@@ -1,4 +1,4 @@
-import { ChannelLogsQueryOptions, Client, Message, TextChannel } from 'discord.js';
+import { ChannelLogsQueryOptions, Client, Message, MessageReaction, TextChannel } from 'discord.js';
 import * as log4js from 'log4js';
 import BotConfig from './BotConfig';
 import ErrorEventHandler from './events/discord/ErrorEventHandler';
@@ -121,11 +121,14 @@ export default class MojiraBot {
 					while ( true ) {
 						const options: ChannelLogsQueryOptions = { limit: 1, before: lastId };
 						const message = ( await requestChannel.messages.fetch( options ) ).first();
-						if ( message?.reactions?.cache.size === 0 ) {
-							try {
-								await newRequestHandler.onEvent( message );
-							} catch ( error ) {
-								MojiraBot.logger.error( error );
+						const addedByBot = ( r: MessageReaction ): boolean => !!r.users.cache.find( u => u.id === MojiraBot.client.user.id );
+						if ( !message?.reactions?.cache.find( addedByBot ) ) {
+							if ( message?.reactions?.cache.size === 0 ) {
+								try {
+									await newRequestHandler.onEvent( message );
+								} catch ( error ) {
+									MojiraBot.logger.error( error );
+								}
 							}
 
 							lastId = message.id;

--- a/src/tasks/FilterFeedTask.ts
+++ b/src/tasks/FilterFeedTask.ts
@@ -83,6 +83,7 @@ export default class FilterFeedTask extends Task {
 		if ( unknownTickets.length > 0 ) {
 			try {
 				const embed = await MentionRegistry.getMention( unknownTickets ).getEmbed();
+				embed.setFooter( `#${ process.pid }` );
 
 				let message = '';
 


### PR DESCRIPTION
## Purpose
Fix backtracking requests. Now the bot will backtrack to the last request that was reacted by the bot. Requests that have already been reacted by human beings won't be forwarded.

Also added the process ID to the footer of filter feed.

## Future work
