### PR TITLE
Improve deployment process

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,15 +28,15 @@ jobs:
           ${{ runner.os }}-node-
 
     - name: Install dependencies
-      run: npm install
-
-    - name: Check code style
-      run: npm run lint --if-present
+      run: npm i -D --no-audit
       
     - name: Compile to JavaScript
       run: npm run build --if-present
       env:
         CI: true
+    
+    - name: Prune dependencies
+      run: npm prune --production
         
     - name: Upload new binaries
       uses: urielsalis/rsync-deploy@v1.4
@@ -44,6 +44,17 @@ jobs:
         DEPLOY_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         SERVER_PORT: 22
         FOLDER: "bin"
+        ARGS: "-avh --delete"
+        SERVER_IP: ssh.urielsalis.com
+        USERNAME: ${{ secrets.REMOTE_USER }}
+        SERVER_DESTINATION: /home/mojiradiscordbot/mojira-discord-bot
+    
+    - name: Upload new dependencies
+      uses: urielsalis/rsync-deploy@v1.4
+      env:
+        DEPLOY_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        SERVER_PORT: 22
+        FOLDER: "node_modules"
         ARGS: "-avh --delete"
         SERVER_IP: ssh.urielsalis.com
         USERNAME: ${{ secrets.REMOTE_USER }}
@@ -71,24 +82,13 @@ jobs:
         USERNAME: ${{ secrets.REMOTE_USER }}
         SERVER_DESTINATION: /home/mojiradiscordbot/mojira-discord-bot
 
-    - name: Update package.json
+    - name: Update shell files
       uses: urielsalis/rsync-deploy@v1.4
       env:
         DEPLOY_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         SERVER_PORT: 22
-        FOLDER: "package.json"
-        ARGS: "-avh --delete"
-        SERVER_IP: ssh.urielsalis.com
-        USERNAME: ${{ secrets.REMOTE_USER }}
-        SERVER_DESTINATION: /home/mojiradiscordbot/mojira-discord-bot
-
-    - name: Update package-lock.json
-      uses: urielsalis/rsync-deploy@v1.4
-      env:
-        DEPLOY_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-        SERVER_PORT: 22
-        FOLDER: "package-lock.json"
-        ARGS: "-avh --delete"
+        FOLDER: "*.sh"
+        ARGS: "-avh"
         SERVER_IP: ssh.urielsalis.com
         USERNAME: ${{ secrets.REMOTE_USER }}
         SERVER_DESTINATION: /home/mojiradiscordbot/mojira-discord-bot
@@ -100,8 +100,6 @@ jobs:
         user: ${{ secrets.REMOTE_USER }}
         key: ${{ secrets.SSH_PRIVATE_KEY }}
         command: |
-          /usr/bin/screen -ls | /bin/grep Detached | /usr/bin/cut -d. -f1 | /usr/bin/awk '{print $1}' | /usr/bin/xargs /bin/kill
-          sleep 1
           cd mojira-discord-bot
-          /usr/bin/screen -d -m bash -c 'npm install && NODE_ENV=main node bin; exec sh'
+          ./restart.sh main
         args: "-tt"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,16 +28,16 @@ jobs:
           ${{ runner.os }}-node-
 
     - name: Install dependencies
-      run: npm i -D --no-audit
-      
+      run: npm i --no-audit
+
     - name: Compile to JavaScript
-      run: npm run build --if-present
+      run: npm run build
       env:
         CI: true
-    
+
     - name: Prune dependencies
       run: npm prune --production
-        
+
     - name: Upload new binaries
       uses: urielsalis/rsync-deploy@v1.4
       env:
@@ -48,7 +48,7 @@ jobs:
         SERVER_IP: ssh.urielsalis.com
         USERNAME: ${{ secrets.REMOTE_USER }}
         SERVER_DESTINATION: /home/mojiradiscordbot/mojira-discord-bot
-    
+
     - name: Upload new dependencies
       uses: urielsalis/rsync-deploy@v1.4
       env:
@@ -60,24 +60,13 @@ jobs:
         USERNAME: ${{ secrets.REMOTE_USER }}
         SERVER_DESTINATION: /home/mojiradiscordbot/mojira-discord-bot
 
-    - name: Delete previous config
-      uses: fifsky/ssh-action@master
-      with:
-        host: ssh.urielsalis.com
-        user: ${{ secrets.REMOTE_USER }}
-        key: ${{ secrets.SSH_PRIVATE_KEY }}
-        command: |
-          cd mojira-discord-bot
-          find ./config -type f -not -name 'local.yml' -a -not -name 'local-*.yml' -print0 | xargs -0 rm -f
-        args: "-tt"
-
     - name: Update config
       uses: urielsalis/rsync-deploy@v1.4
       env:
         DEPLOY_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         SERVER_PORT: 22
         FOLDER: "config"
-        ARGS: "-avh"
+        ARGS: "-avh --delete --exclude='local.yml' --exclude='local-*.yml'"
         SERVER_IP: ssh.urielsalis.com
         USERNAME: ${{ secrets.REMOTE_USER }}
         SERVER_DESTINATION: /home/mojiradiscordbot/mojira-discord-bot

--- a/README.md
+++ b/README.md
@@ -64,13 +64,27 @@ You can create another configuration like that for your own bot.
 An overview / documentation of all config options can be found in `template.yml`.
 
 ### Running
-To run the bot, you need to run the following command:
+#### Testing / development
+For testing or development purposes, it is recommended to run the bot using the following command:
 
 ```
 NODE_ENV=<deployment> npm run bot
 ```
 
 where `<deployment>` is the name of a deployment configuration (`main` or `beta`).
+
+#### Deployment
+To deploy the bot, you need to run the following command:
+
+```
+./start.sh <deployment>
+```
+
+where `<deployment>` is the name of a deployment configuration (`main` or `beta`).
+
+Note that the bot is started in a detached screen, which means you won't see any output and the bot is running in the background.
+
+You can stop the bot with `./stop.sh <deployment>` or restart it with `./restart.sh <deployment>`.
 
 ## Built with
 

--- a/index.ts
+++ b/index.ts
@@ -41,6 +41,7 @@ try {
 		MojiraBot.logger.info( `Writing log to ${ logConfig.appenders.log[ 'filename' ] }` );
 	}
 
+	// eslint-disable-next-line @typescript-eslint/no-floating-promises
 	MojiraBot.start();
 } catch ( err ) {
 	MojiraBot.logger.error( err );

--- a/package-lock.json
+++ b/package-lock.json
@@ -487,14 +487,12 @@
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
       "version": "6.8.0",
@@ -1664,7 +1662,8 @@
     "typescript": {
       "version": "3.9.7",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "dev": true
     },
     "universalify": {
       "version": "0.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,15 +70,15 @@
       "dev": true
     },
     "@types/json-schema": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
-      "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
+      "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.35",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.35.tgz",
-      "integrity": "sha512-ASYsaKecA7TUsDrqIGPNk3JeEox0z/0XR/WsJJ8BIX/9+SkMSImQXKWfU/yBrSyc7ZSE/NPqLu36Nur0miCFfQ==",
+      "version": "12.19.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.4.tgz",
+      "integrity": "sha512-o3oj1bETk8kBwzz1WlO6JWL/AfAA3Vm6J1B3C9CsdxHYp7XgPiH7OEXPUbZTndHlRaIElrANkQfe6ZmfJb3H2w==",
       "dev": true
     },
     "@types/node-fetch": {
@@ -105,45 +105,45 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.27.0.tgz",
-      "integrity": "sha512-/my+vVHRN7zYgcp0n4z5A6HAK7bvKGBiswaM5zIlOQczsxj/aiD7RcgD+dvVFuwFaGh5+kM7XA6Q6PN0bvb1tw==",
+      "version": "2.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz",
+      "integrity": "sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.27.0",
+        "@typescript-eslint/experimental-utils": "2.34.0",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
         "tsutils": "^3.17.1"
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.27.0.tgz",
-      "integrity": "sha512-vOsYzjwJlY6E0NJRXPTeCGqjv5OHgRU1kzxHKWJVPjDYGbPgLudBXjIlc+OD1hDBZ4l1DLbOc5VjofKahsu9Jw==",
+      "version": "2.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz",
+      "integrity": "sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.27.0",
+        "@typescript-eslint/typescript-estree": "2.34.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.27.0.tgz",
-      "integrity": "sha512-HFUXZY+EdwrJXZo31DW4IS1ujQW3krzlRjBrFRrJcMDh0zCu107/nRfhk/uBasO8m0NVDbBF5WZKcIUMRO7vPg==",
+      "version": "2.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.34.0.tgz",
+      "integrity": "sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.27.0",
-        "@typescript-eslint/typescript-estree": "2.27.0",
+        "@typescript-eslint/experimental-utils": "2.34.0",
+        "@typescript-eslint/typescript-estree": "2.34.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.27.0.tgz",
-      "integrity": "sha512-t2miCCJIb/FU8yArjAvxllxbTiyNqaXJag7UOpB5DVoM3+xnjeOngtqlJkLRnMtzaRcJhe3CIR9RmL40omubhg==",
+      "version": "2.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz",
+      "integrity": "sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -151,8 +151,16 @@
         "glob": "^7.1.6",
         "is-glob": "^4.0.1",
         "lodash": "^4.17.15",
-        "semver": "^6.3.0",
+        "semver": "^7.3.2",
         "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        }
       }
     },
     "abort-controller": {
@@ -373,9 +381,9 @@
       "dev": true
     },
     "config": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/config/-/config-3.3.1.tgz",
-      "integrity": "sha512-+2/KaaaAzdwUBE3jgZON11L1ggLLhpf2FsGrfqYFHZW22ySGv/HqYIXrBwKKvn+XZh1UBUjHwAcrfsSkSygT+Q==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/config/-/config-3.3.2.tgz",
+      "integrity": "sha512-NlGfBn2565YA44Irn7GV5KHlIGC3KJbf0062/zW5ddP9VXIuRj0m7HVyFAWvMZvaHPEglyGfwmevGz3KosIpCg==",
       "requires": {
         "json5": "^2.1.1"
       }
@@ -444,18 +452,18 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "discord.js": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-12.2.0.tgz",
-      "integrity": "sha512-Ueb/0SOsxXyqwvwFYFe0msMrGqH1OMqpp2Dpbplnlr4MzcRrFWwsBM9gKNZXPVBHWUKiQkwU8AihXBXIvTTSvg==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-12.4.1.tgz",
+      "integrity": "sha512-KxOB8LOAN3GmrvkD6a6Fr1nlfArIFZ+q7Uqg4T/5duB90GZy9a0/Py2E+Y+eHKP6ZUCR2mbNMLCcHGjahiaNqA==",
       "requires": {
-        "@discordjs/collection": "^0.1.5",
+        "@discordjs/collection": "^0.1.6",
         "@discordjs/form-data": "^3.0.1",
         "abort-controller": "^3.0.0",
-        "node-fetch": "^2.6.0",
-        "prism-media": "^1.2.0",
+        "node-fetch": "^2.6.1",
+        "prism-media": "^1.2.2",
         "setimmediate": "^1.0.5",
         "tweetnacl": "^1.0.3",
-        "ws": "^7.2.1"
+        "ws": "^7.3.1"
       }
     },
     "doctrine": {
@@ -561,9 +569,9 @@
       }
     },
     "eslint-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
-      "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
@@ -1090,15 +1098,15 @@
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "log4js": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.1.2.tgz",
-      "integrity": "sha512-knS4Y30pC1e0n7rfx3VxcLOdBCsEo0o6/C7PVTGxdVK+5b1TYOSGQPn9FDcrhkoQBV29qwmA2mtkznPAQKnxQg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.3.0.tgz",
+      "integrity": "sha512-Mc8jNuSFImQUIateBFwdOQcmC6Q5maU0VVvdC2R6XMb66/VnT+7WS4D/0EeNMZu1YODmJe5NIn2XftCzEocUgw==",
       "requires": {
         "date-format": "^3.0.0",
         "debug": "^4.1.1",
         "flatted": "^2.0.1",
         "rfdc": "^1.1.4",
-        "streamroller": "^2.2.3"
+        "streamroller": "^2.2.4"
       }
     },
     "mime-db": {
@@ -1144,9 +1152,9 @@
       }
     },
     "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "ms": {
       "version": "2.1.2",
@@ -1468,9 +1476,9 @@
       }
     },
     "streamroller": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.3.tgz",
-      "integrity": "sha512-AegmvQsscTRhHVO46PhCDerjIpxi7E+d2GxgUDu+nzw/HuLnUdxHWr6WQ+mVn/4iJgMKKFFdiUwFcFRDvcjCtw==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.4.tgz",
+      "integrity": "sha512-OG79qm3AujAM9ImoqgWEY1xG4HX+Lw+yY6qZj9R1K2mhF5bEmQ849wvrb+4vt4jLMLzwXttJlQbOdPOQVRv7DQ==",
       "requires": {
         "date-format": "^2.1.0",
         "debug": "^4.1.1",
@@ -1654,9 +1662,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w=="
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
     },
     "universalify": {
       "version": "0.1.2",
@@ -1723,9 +1731,9 @@
       }
     },
     "ws": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
+      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,12 +19,13 @@
   "dependencies": {
     "config": "^3.3.2",
     "discord.js": "^12.4.1",
+    "emoji-regex": "^8.0.0",
+    "escape-string-regexp": "^1.0.5",
     "jira-connector": "^3.1.0",
     "js-yaml": "^3.14.0",
     "log4js": "^6.3.0",
     "moment": "^2.29.1",
-    "node-fetch": "^2.6.1",
-    "typescript": "^3.9.7"
+    "node-fetch": "^2.6.1"
   },
   "devDependencies": {
     "@types/config": "0.0.36",
@@ -33,6 +34,7 @@
     "@types/node-fetch": "^2.5.7",
     "@typescript-eslint/eslint-plugin": "^2.34.0",
     "@typescript-eslint/parser": "^2.34.0",
-    "eslint": "^6.8.0"
+    "eslint": "^6.8.0",
+    "typescript": "^3.9.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,22 +17,22 @@
     "lintfix": "eslint src/**/*.ts --fix"
   },
   "dependencies": {
-    "config": "^3.3.1",
-    "discord.js": "^12.2.0",
+    "config": "^3.3.2",
+    "discord.js": "^12.4.1",
     "jira-connector": "^3.1.0",
     "js-yaml": "^3.14.0",
-    "log4js": "^6.1.2",
-    "moment": "^2.24.0",
+    "log4js": "^6.3.0",
+    "moment": "^2.29.1",
     "node-fetch": "^2.6.1",
-    "typescript": "^3.8.3"
+    "typescript": "^3.9.7"
   },
   "devDependencies": {
     "@types/config": "0.0.36",
     "@types/emoji-regex": "^8.0.0",
-    "@types/node": "^12.12.35",
+    "@types/node": "^12.19.4",
     "@types/node-fetch": "^2.5.7",
-    "@typescript-eslint/eslint-plugin": "^2.27.0",
-    "@typescript-eslint/parser": "^2.27.0",
+    "@typescript-eslint/eslint-plugin": "^2.34.0",
+    "@typescript-eslint/parser": "^2.34.0",
     "eslint": "^6.8.0"
   }
 }

--- a/restart.sh
+++ b/restart.sh
@@ -1,0 +1,2 @@
+./stop.sh $1
+./start.sh $1

--- a/src/commands/PollCommand.ts
+++ b/src/commands/PollCommand.ts
@@ -67,7 +67,7 @@ export default class PollCommand extends PrefixCommand {
 			embed.addField( option.emoji, option.text, true );
 		}
 
-		let poll = await message.channel.send( { embed: embed, disableEveryone: !message.member.hasPermission( 'MENTION_EVERYONE' ) } );
+		let poll = await message.channel.send( { embed: embed, disableMentions: 'all' } );
 
 		if ( poll instanceof Array ) {
 			if ( poll.length == 0 ) {

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,2 @@
+# Start a screen called "mojiradiscordbot-<deployment>" with the node process
+/usr/bin/screen -S mojiradiscordbot-$1 -d -m bash -c "NODE_ENV=$1 node bin" ; exit

--- a/stop.sh
+++ b/stop.sh
@@ -1,0 +1,2 @@
+# Send ^C to screen session window
+screen -S mojiradiscordbot-$1 -X stuff $'\003'


### PR DESCRIPTION
## Purpose
This PR has multiple purposes:

1. No longer download dependencies twice (once while building and once before start)
2. Make deployment process more robust and faster
3. Ensure that the bot always is shut down gracefully by CI/CD in order to fix #115
4. Provide easy tools to start/stop the bot from the command line

## Approach
1. Prune the dependencies after building and directly send them over to the server via rsync (typically only about 15 MB from my testing,. usually even less with caching thanks to rsync ignoring unchanged files)
2. Only ship compiled JS files and execute them directly via `node` instead of relying on `npm`. Only stop the bot after new files have been deployed.
3. Let the bot listen for SIGINT and SIGTERM signals, and send ^C via a script when the bot is shutdown by CI/CD
4. Added `start.sh`, `stop.sh` and `restart.sh` that can be used both by human users and CI/CD. Note: Environment argument needs to be applied. E.g.: Use `./stop.sh main` to stop the main bot.

## Future work
* Monitor how reliable the new deployment process is
* Improve `start.sh`, `stop.sh` and `restart.sh` to make them more user-friendly (CLI feedback)