### PR TITLE
Refactor request backtracking

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -43,5 +43,4 @@ request:
     {{author}} {{url}}
     {{message}}
     
-    <Enter your response here>
     ```

--- a/src/MojiraBot.ts
+++ b/src/MojiraBot.ts
@@ -1,4 +1,4 @@
-import { ChannelLogsQueryOptions, Client, Message, TextChannel } from 'discord.js';
+import { ChannelLogsQueryOptions, Client, Message, MessageReaction, TextChannel } from 'discord.js';
 import * as log4js from 'log4js';
 import BotConfig from './BotConfig';
 import ErrorEventHandler from './events/discord/ErrorEventHandler';
@@ -121,11 +121,14 @@ export default class MojiraBot {
 					while ( true ) {
 						const options: ChannelLogsQueryOptions = { limit: 1, before: lastId };
 						const message = ( await requestChannel.messages.fetch( options ) ).first();
-						if ( message?.reactions?.cache.size === 0 ) {
-							try {
-								await newRequestHandler.onEvent( message );
-							} catch ( error ) {
-								MojiraBot.logger.error( error );
+						const addedByBot = ( r: MessageReaction ): boolean => !!r.users.cache.find( u => u.id === MojiraBot.client.user.id );
+						if ( !message?.reactions?.cache.find( addedByBot ) ) {
+							if ( message?.reactions?.cache.size === 0 ) {
+								try {
+									await newRequestHandler.onEvent( message );
+								} catch ( error ) {
+									MojiraBot.logger.error( error );
+								}
 							}
 
 							lastId = message.id;

--- a/src/events/request/RequestEventHandler.ts
+++ b/src/events/request/RequestEventHandler.ts
@@ -27,7 +27,9 @@ export default class RequestEventHandler implements EventHandler<'message'> {
 			return;
 		}
 
-		this.logger.info( `User ${ origin.author.tag } posted a new request to requests channel ${ origin.channel.id }` );
+		if ( origin.channel instanceof TextChannel ) {
+			this.logger.info( `${ origin.author.tag } posted request ${ origin.id } in #${ origin.channel.name }` );
+		}
 
 		try {
 			await origin.reactions.removeAll();
@@ -45,7 +47,7 @@ export default class RequestEventHandler implements EventHandler<'message'> {
 			}
 
 			try {
-				const warning = await origin.channel.send( `${ origin.author }, your request doesn't contain any valid ticket reference. If you'd like to add it you can edit your message.` );
+				const warning = await origin.channel.send( `${ origin.author }, your request (<${ origin.url }>) doesn't contain any valid ticket reference. If you'd like to add it you can edit your message.` );
 
 				const timeout = BotConfig.request.noLinkWarningLifetime;
 				await warning.delete( { timeout } );
@@ -92,6 +94,6 @@ export default class RequestEventHandler implements EventHandler<'message'> {
 	private replaceTicketReferencesWithRichLinks( content: string, regex: RegExp ): string {
 		// Only one of the two capture groups ($1 and $2) can catch an ID at the same time.
 		// `$1$2` is used to get the ID from either of the two groups.
-		return content.replace( /([\[\]])/gm, '\\$1' ).replace( regex, '[$1$2](https://bugs.mojang.com/browse/$1$2$3)' );
+		return content.replace( /([[\]])/gm, '\\$1' ).replace( regex, '[$1$2](https://bugs.mojang.com/browse/$1$2$3)' );
 	}
 }

--- a/src/tasks/FilterFeedTask.ts
+++ b/src/tasks/FilterFeedTask.ts
@@ -83,6 +83,7 @@ export default class FilterFeedTask extends Task {
 		if ( unknownTickets.length > 0 ) {
 			try {
 				const embed = await MentionRegistry.getMention( unknownTickets ).getEmbed();
+				embed.setFooter( `#${ process.pid }` );
 
 				let message = '';
 


### PR DESCRIPTION
## Purpose
This PR is based on #122 and has the same goals. I've refactored this piece of code so that it's easier to read and less error-prone.

## Approach
* Put all messages without reactions into a list until you find the first message with a bot reaction
* Go through the list, the oldest requests are handled first

## Future work
* Extract all the "catching up" functionality from `MojiraBot`
* Refactor other parts of bot setup