### PR TITLE
Add an emoji to show the prependResponseMessage without resolving the request

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -31,8 +31,10 @@ request:
     - ✅
     - ☑️
     - ❌
+    - 💬
   
   ignorePrependResponseMessageEmoji: ✅
+  ignoreResolutionEmoji: 💬
 
   resolveDelay: 10000
   prependResponseMessage: whenResolved

--- a/config/default.yml
+++ b/config/default.yml
@@ -31,10 +31,10 @@ request:
     - ✅
     - ☑️
     - ❌
-    - 💬
+    - :speech_balloon:
   
   ignorePrependResponseMessageEmoji: ✅
-  ignoreResolutionEmoji: 💬
+  ignoreResolutionEmoji: :speech_balloon:
 
   resolveDelay: 10000
   prependResponseMessage: whenResolved

--- a/config/default.yml
+++ b/config/default.yml
@@ -31,10 +31,10 @@ request:
     - ✅
     - ☑️
     - ❌
-    - :speech_balloon:
+    - 💬
   
   ignorePrependResponseMessageEmoji: ✅
-  ignoreResolutionEmoji: :speech_balloon:
+  ignoreResolutionEmoji: 💬
 
   resolveDelay: 10000
   prependResponseMessage: whenResolved

--- a/src/BotConfig.ts
+++ b/src/BotConfig.ts
@@ -24,6 +24,7 @@ export class RequestConfig {
 	public waitingEmoji: string;
 	public suggestedEmoji: string[];
 	public ignorePrependResponseMessageEmoji: string;
+	public ignoreResolutionEmoji: string;
 	public resolveDelay: number;
 	public prependResponseMessage: PrependResponseMessageType;
 	public prependResponseMessageInLog: boolean;
@@ -43,6 +44,7 @@ export class RequestConfig {
 		this.waitingEmoji = config.get( 'request.waitingEmoji' );
 		this.suggestedEmoji = getOrDefault( 'request.suggestedEmoji', [] );
 		this.ignorePrependResponseMessageEmoji = config.get( 'request.ignorePrependResponseMessageEmoji' );
+		this.ignoreResolutionEmoji = config.get( 'request.ignoreResolutionEmoji' );
 
 		this.resolveDelay = config.get( 'request.resolveDelay' );
 		this.prependResponseMessage = getOrDefault( 'request.prependResponseMessage', PrependResponseMessageType.Never );

--- a/src/events/request/RequestResolveEventHandler.ts
+++ b/src/events/request/RequestResolveEventHandler.ts
@@ -29,10 +29,12 @@ export default class RequestResolveEventHandler implements EventHandler<'message
 			}
 		}
 
-		TaskScheduler.addOneTimeMessageTask(
-			reaction.message,
-			new ResolveRequestMessageTask( reaction.emoji, user ),
-			BotConfig.request.resolveDelay || 0
-		);
+		if ( BotConfig.request.ignoreResolutionEmoji !== reaction.emoji.name ) {
+			TaskScheduler.addOneTimeMessageTask(
+				reaction.message,
+				new ResolveRequestMessageTask( reaction.emoji, user ),
+				BotConfig.request.resolveDelay || 0
+			);
+		}
 	};
 }


### PR DESCRIPTION
Closes #121 

A similar workflow to what was mentioned in the comments on that issue, with a few changes:

1. user triggers the dedicated "reply" reaction on the internal request (:speech_balloon: emoji)
2. bot edits internal request to add the preview
3. bot does **not** remove preview until...
4. user removes the dedicated "reply" reaction
5. bot removes the preview

I have set it up so that the user does not have to worry about the request being resolved, and so that the user also does not have to act that fast to get the message. The only thing to remember is the user still has to remove the speech bubble in order to remove the message.