### PR TITLE
Specify all non-privileged intents when setting up the bot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -381,9 +381,9 @@
       "dev": true
     },
     "config": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/config/-/config-3.3.2.tgz",
-      "integrity": "sha512-NlGfBn2565YA44Irn7GV5KHlIGC3KJbf0062/zW5ddP9VXIuRj0m7HVyFAWvMZvaHPEglyGfwmevGz3KosIpCg==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/config/-/config-3.3.3.tgz",
+      "integrity": "sha512-T3RmZQEAji5KYqUQpziWtyGJFli6Khz7h0rpxDwYNjSkr5ynyTWwO7WpfjHzTXclNCDfSWQRcwMb+NwxJesCKw==",
       "requires": {
         "json5": "^2.1.1"
       }
@@ -452,9 +452,9 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "discord.js": {
-      "version": "12.4.1",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-12.4.1.tgz",
-      "integrity": "sha512-KxOB8LOAN3GmrvkD6a6Fr1nlfArIFZ+q7Uqg4T/5duB90GZy9a0/Py2E+Y+eHKP6ZUCR2mbNMLCcHGjahiaNqA==",
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-12.5.1.tgz",
+      "integrity": "sha512-VwZkVaUAIOB9mKdca0I5MefPMTQJTNg0qdgi1huF3iwsFwJ0L5s/Y69AQe+iPmjuV6j9rtKoG0Ta0n9vgEIL6w==",
       "requires": {
         "@discordjs/collection": "^0.1.6",
         "@discordjs/form-data": "^3.0.1",
@@ -789,9 +789,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "har-schema": {
       "version": "2.0.0",

--- a/src/MojiraBot.ts
+++ b/src/MojiraBot.ts
@@ -1,4 +1,4 @@
-import { ChannelLogsQueryOptions, Client, Message, TextChannel } from 'discord.js';
+import { ChannelLogsQueryOptions, Client, Intents, Message, TextChannel } from 'discord.js';
 import * as log4js from 'log4js';
 import BotConfig from './BotConfig';
 import ErrorEventHandler from './events/discord/ErrorEventHandler';
@@ -25,7 +25,12 @@ import { RoleSelectionUtil } from './util/RoleSelectionUtil';
 export default class MojiraBot {
 	public static logger = log4js.getLogger( 'MojiraBot' );
 
-	public static client: Client = new Client( { partials: ['REACTION'] } );
+	public static client: Client = new Client( {
+		partials: ['REACTION'],
+		ws: {
+			intents: Intents.NON_PRIVILEGED,
+		},
+	} );
 	private static running = false;
 
 	public static async start(): Promise<void> {


### PR DESCRIPTION
## Purpose
Fix attempt for #125.

## Approach
Specify all non-privileged intents when setting up the bot, so that hopefully the bot should now get all reaction events no matter what.

## Future work
See if the fix worked.