### PR TITLE
Fetch latest 100 messages from the request log on startup

### DIFF
--- a/src/MojiraBot.ts
+++ b/src/MojiraBot.ts
@@ -133,6 +133,18 @@ export default class MojiraBot {
 					}
 				}
 
+                                if ( BotConfig.request.logChannel ) {
+                                        try {
+                                                const logChannel = await Discord until.getChannel( BotConfig.request.logChannel );
+                                                if ( logChannel instanceof TextChannel ) {
+                                                        const messages = ChannelLogsQueryOptions = { limit: 100 };
+                                                        await logChannel.messages.fetch( messages );
+                                                }
+                                        } catch ( err ) {
+						this.logger.error( err );
+					}
+                                }
+
 				const newRequestHandler = new RequestEventHandler( internalChannels );
 				for ( const requestChannel of requestChannels ) {
 					this.logger.info( `Catching up on requests from #${ requestChannel.name }...` );

--- a/src/MojiraBot.ts
+++ b/src/MojiraBot.ts
@@ -135,7 +135,7 @@ export default class MojiraBot {
 
                                 if ( BotConfig.request.logChannel ) {
                                         try {
-                                                const logChannel = await Discord until.getChannel( BotConfig.request.logChannel );
+                                                const logChannel = await DiscordUtil.getChannel( BotConfig.request.logChannel );
                                                 if ( logChannel instanceof TextChannel ) {
                                                         const messages = ChannelLogsQueryOptions = { limit: 100 };
                                                         await logChannel.messages.fetch( messages );

--- a/src/MojiraBot.ts
+++ b/src/MojiraBot.ts
@@ -137,7 +137,7 @@ export default class MojiraBot {
                                         try {
                                                 const logChannel = await DiscordUtil.getChannel( BotConfig.request.logChannel );
                                                 if ( logChannel instanceof TextChannel ) {
-                                                        const messages = ChannelLogsQueryOptions = { limit: 100 };
+                                                        const messages: ChannelLogsQueryOptions = { limit: 100 };
                                                         await logChannel.messages.fetch( messages );
                                                 }
                                         } catch ( err ) {

--- a/src/MojiraBot.ts
+++ b/src/MojiraBot.ts
@@ -137,8 +137,7 @@ export default class MojiraBot {
                                         try {
                                                 const logChannel = await DiscordUtil.getChannel( BotConfig.request.logChannel );
                                                 if ( logChannel instanceof TextChannel ) {
-                                                        const messages: ChannelLogsQueryOptions = { limit: 100 };
-                                                        await logChannel.messages.fetch( messages );
+                                                        await logChannel.messages.fetch( { limit: 100 } );
                                                 }
                                         } catch ( err ) {
 						this.logger.error( err );


### PR DESCRIPTION
## Purpose
Fix #132 
## Approach
Caches the latest 100 messages in the request log in order to see reactions to them. Fetching all messages from the channel seems excessive and unnecessary.
## Future work
