### PR TITLE
Enable bulk action by Jira filter

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -32,6 +32,7 @@ request:
     - ☑️
     - ❌
     - 💬
+    - 📁
   
   ignorePrependResponseMessageEmoji: ✅
   ignoreResolutionEmoji: 💬

--- a/config/default.yml
+++ b/config/default.yml
@@ -35,6 +35,7 @@ request:
   
   ignorePrependResponseMessageEmoji: ✅
   ignoreResolutionEmoji: 💬
+  bulkEmoji: 📁
 
   resolveDelay: 10000
   prependResponseMessage: whenResolved

--- a/config/template.yml
+++ b/config/template.yml
@@ -84,6 +84,9 @@ request:
   # An emoji or emoji ID which, when used, doesn't trigger the response template message.
   ignorePrependResponseMessageEmoji: <string>
 
+  # An emoji or emoji ID which indicates a request message to be added to a bulk action.
+  bulkEmoji: <string>
+
   # The amount of time in milliseconds between a volunteer reacts to the message and the bot deletes its message.
   resolveDelay: <number>
 

--- a/src/BotConfig.ts
+++ b/src/BotConfig.ts
@@ -25,6 +25,7 @@ export class RequestConfig {
 	public suggestedEmoji: string[];
 	public ignorePrependResponseMessageEmoji: string;
 	public ignoreResolutionEmoji: string;
+	public bulkEmoji: string;
 	public resolveDelay: number;
 	public prependResponseMessage: PrependResponseMessageType;
 	public prependResponseMessageInLog: boolean;
@@ -45,6 +46,7 @@ export class RequestConfig {
 		this.suggestedEmoji = getOrDefault( 'request.suggestedEmoji', [] );
 		this.ignorePrependResponseMessageEmoji = config.get( 'request.ignorePrependResponseMessageEmoji' );
 		this.ignoreResolutionEmoji = config.get( 'request.ignoreResolutionEmoji' );
+		this.bulkEmoji = config.get( 'request.bulkEmoji' );
 
 		this.resolveDelay = config.get( 'request.resolveDelay' );
 		this.prependResponseMessage = getOrDefault( 'request.prependResponseMessage', PrependResponseMessageType.Never );

--- a/src/commands/BulkCommand.ts
+++ b/src/commands/BulkCommand.ts
@@ -54,7 +54,7 @@ export default class BulkCommand extends PrefixCommand {
 			Command.logger.error( err );
 			return false;
 		}
-		const filter = `https://bugs.mojang.com/browse/${ firstMentioned }?jql=key%20in(${ ticketKeys.join( '%2C' ) })`
+		const filter = `https://bugs.mojang.com/browse/${ firstMentioned }?jql=key%20in(${ ticketKeys.join( '%2C' ) })`;
 		try {
 			await message.channel.send( `${ message.author.toString() } ${ filter }` );
 		} catch {

--- a/src/commands/BulkCommand.ts
+++ b/src/commands/BulkCommand.ts
@@ -20,7 +20,7 @@ export default class BulkCommand extends PrefixCommand {
 			try {
 				const internalChannel = await DiscordUtil.getChannel( internalChannelId );
 				if ( internalChannel instanceof TextChannel ) {
-					const channelMessages = internalChannel.messages;
+					const channelMessages = internalChannel.messages.cache;
 					for await ( const channelMessage of channelMessages ) {
 						const reaction = channelMessage.reactions.cache.get( BotConfig.request.bulkEmoji );
 						if ( reaction.users.cache.get( message.author ) ) {

--- a/src/commands/BulkCommand.ts
+++ b/src/commands/BulkCommand.ts
@@ -13,7 +13,7 @@ export default class BulkCommand extends PrefixCommand {
 			return false;
 		}
 
-		let bulkMessages: Messages[];
+		let bulkMessages: Message[];
 
 		for ( let i = 0; i < BotConfig.request.internalChannels.length; i++ ) {
 			const internalChannelId = BotConfig.request.internalChannels[i];

--- a/src/commands/BulkCommand.ts
+++ b/src/commands/BulkCommand.ts
@@ -32,7 +32,7 @@ export default class BulkCommand extends PrefixCommand {
 				Command.logger.error( err );
 				return false;
 			}
-	        }
+		}
 
 		let firstMentioned: string;
 		let ticketKeys: string[];

--- a/src/commands/BulkCommand.ts
+++ b/src/commands/BulkCommand.ts
@@ -21,7 +21,7 @@ export default class BulkCommand extends PrefixCommand {
 				const internalChannel = await DiscordUtil.getChannel( internalChannelId );
 				if ( internalChannel instanceof TextChannel ) {
 					const channelMessages = internalChannel.messages;
-					for ( const channelMessage of channelMessages ) {
+					for await ( const channelMessage of channelMessages ) {
 						const reaction = channelMessage.reactions.cache.get( BotConfig.request.bulkEmoji );
 						if ( reaction.users.cache.get( message.author ) ) {
 							bulkMessages.add( channelMessage );

--- a/src/commands/BulkCommand.ts
+++ b/src/commands/BulkCommand.ts
@@ -13,7 +13,7 @@ export default class BulkCommand extends PrefixCommand {
 			return false;
 		}
 
-		let bulkMessages: Set<Message>;
+		let bulkMessages: Messages[];
 
 		for ( let i = 0; i < BotConfig.request.internalChannels.length; i++ ) {
 			const internalChannelId = BotConfig.request.internalChannels[i];
@@ -24,7 +24,7 @@ export default class BulkCommand extends PrefixCommand {
 					for await ( const channelMessage of channelMessages ) {
 						const reaction = channelMessage.reactions.cache.get( BotConfig.request.bulkEmoji );
 						if ( reaction.users.cache.get( message.author.id ) ) {
-							bulkMessages.add( channelMessage );
+							bulkMessages.push( channelMessage );
 						}
 					}
 				}
@@ -32,17 +32,15 @@ export default class BulkCommand extends PrefixCommand {
 				Command.logger.error( err );
 				return false;
 			}
-		}
-
-		const bulkMessageArray = Array.from( bulkMessages );
+	        }
 
 		let firstMentioned: string;
 		let ticketKeys: string[];
 
 		try {
-			for ( let j = 0; j < bulkMessageArray.length; j++ ) {
-				const bulkMessage = bulkMessageArray[j];
-				const ticket = Array.from( this.getTickets( bulkMessage.toString() ) );
+			for ( let j = 0; j < bulkMessages.length; j++ ) {
+				const bulkMessage = bulkMessages[j];
+				const ticket = this.getTickets( bulkMessage.toString() );
 				if ( firstMentioned == null ) {
 					firstMentioned = ticket[1];
 				}
@@ -64,12 +62,12 @@ export default class BulkCommand extends PrefixCommand {
 		return true;
 	}
 
-	private getTickets( content: string ): Set<string> {
+	private getTickets( content: string ): string[] {
 		let ticketMatch: RegExpExecArray;
 		const regex = MentionCommand.getTicketIdRegex();
-		const ticketMatches: Set<string> = new Set();
+		const ticketMatches: string[] = [];
 		while ( ( ticketMatch = regex.exec( content ) ) !== null ) {
-			ticketMatches.add( ticketMatch[1] );
+			ticketMatches.push( ticketMatch[1] );
 		}
 		return ticketMatches;
 	}

--- a/src/commands/BulkCommand.ts
+++ b/src/commands/BulkCommand.ts
@@ -13,7 +13,6 @@ export default class BulkCommand extends PrefixCommand {
 			return false;
 		}
 
-		//get messages with bulk reaction from user
 		let bulkMessages: Set<Message>;
 
 		for ( let i = 0; i < BotConfig.request.internalChannels.length; i++ ) {
@@ -21,11 +20,11 @@ export default class BulkCommand extends PrefixCommand {
 			try {
 				const internalChannel = await DiscordUtil.getChannel( internalChannelId );
 				if ( internalChannel instanceof TextChannel ) {
-					const messages = internalChannel.messages;
-					for (const message of messages) {
-						const reaction = message.reactions.cache.get( BotConfig.request.bulkEmoji );
+					const channelMessages = internalChannel.messages;
+					for ( const channelMessage of channelMessages ) {
+						const reaction = channelMessage.reactions.cache.get( BotConfig.request.bulkEmoji );
 						if ( reaction.users.cache.get( message.author ) ) {
-							bulkMessages.add( message );
+							bulkMessages.add( channelMessage );
 						}
 					}
 				}
@@ -37,19 +36,18 @@ export default class BulkCommand extends PrefixCommand {
 
 		const bulkMessageArray = Array.from( bulkMessages );
 
-		//get tickets and create filter
 		let firstMentioned: string;
 		let ticketKeys: string[];
 
 		try {
 			for ( let j = 0; j < bulkMessageArray.length; j++ ) {
-				const message = bulkMessageArray[j];
-				const ticket = Array.from( this.getTickets( message.toString() ) );
+				const bulkMessage = bulkMessageArray[j];
+				const ticket = Array.from( this.getTickets( bulkMessage.toString() ) );
 				if ( firstMentioned == null ) {
 					firstMentioned = ticket[1];
 				}
 				ticket.forEach( key => ticketKeys.push( key ) );
-				const reaction = message.reactions.cache.get( BotConfig.request.bulkEmoji );
+				const reaction = bulkMessage.reactions.cache.get( BotConfig.request.bulkEmoji );
 				await reaction.users.remove( message.author );
 			}
 		} catch ( err ) {

--- a/src/commands/BulkCommand.ts
+++ b/src/commands/BulkCommand.ts
@@ -20,7 +20,7 @@ export default class BulkCommand extends PrefixCommand {
 			try {
 				const internalChannel = await DiscordUtil.getChannel( internalChannelId );
 				if ( internalChannel instanceof TextChannel ) {
-					const channelMessages = internalChannel.messages.cache;
+					const channelMessages = internalChannel.messages.cache.values();
 					for await ( const channelMessage of channelMessages ) {
 						const reaction = channelMessage.reactions.cache.get( BotConfig.request.bulkEmoji );
 						if ( reaction.users.cache.get( message.author ) ) {

--- a/src/commands/BulkCommand.ts
+++ b/src/commands/BulkCommand.ts
@@ -1,0 +1,82 @@
+import { Message, TextChannel } from 'discord.js';
+import PrefixCommand from './PrefixCommand';
+import MentionCommand from './MentionCommand';
+import Command from './Command';
+import DiscordUtil from '../util/DiscordUtil';
+import BotConfig from '../BotConfig';
+
+export default class BulkCommand extends PrefixCommand {
+	public readonly aliases = ['bulk', 'filter'];
+
+	public async run( message: Message, args: string ): Promise<boolean> {
+		if ( args.length ) {
+			return false;
+		}
+
+		//get messages with bulk reaction from user
+		let bulkMessages: Set<Message>;
+
+		for ( let i = 0; i < BotConfig.request.internalChannels.length; i++ ) {
+			const internalChannelId = BotConfig.request.internalChannels[i];
+			try {
+				const internalChannel = await DiscordUtil.getChannel( internalChannelId );
+				if ( internalChannel instanceof TextChannel ) {
+					const messages = internalChannel.messages;
+					for (const message of messages) {
+						const reaction = message.reactions.cache.get( BotConfig.request.bulkEmoji );
+						if ( reaction.users.cache.get( message.author ) ) {
+							bulkMessages.add( message );
+						}
+					}
+				}
+			} catch ( err ) {
+				Command.logger.error( err );
+				return false;
+			}
+		}
+
+		const bulkMessageArray = Array.from( bulkMessages );
+
+		//get tickets and create filter
+		let firstMentioned: string;
+		let ticketKeys: string[];
+
+		try {
+			for ( let j = 0; j < bulkMessageArray.length; j++ ) {
+				const message = bulkMessageArray[j];
+				const ticket = Array.from( this.getTickets( message.toString() ) );
+				if ( firstMentioned == null ) {
+					firstMentioned = ticket[1];
+				}
+				ticket.forEach( key => ticketKeys.push( key ) );
+				const reaction = message.reactions.cache.get( BotConfig.request.bulkEmoji );
+				await reaction.users.remove( message.author );
+			}
+		} catch ( err ) {
+			Command.logger.error( err );
+			return false;
+		}
+		const filter = `https://bugs.mojang.com/browse/${ firstMentioned }?jql=key%20in(${ ticketKeys.join( '%2C' ) })`
+		try {
+			await message.channel.send( `${ message.author.toString() } ${ filter }` );
+		} catch {
+			return false;
+		}
+
+		return true;
+	}
+
+	private getTickets( content: string ): Set<string> {
+		let ticketMatch: RegExpExecArray;
+		const regex = MentionCommand.getTicketIdRegex();
+		const ticketMatches: Set<string> = new Set();
+		while ( ( ticketMatch = regex.exec( content ) ) !== null ) {
+			ticketMatches.add( ticketMatch[1] );
+		}
+		return ticketMatches;
+	}
+
+	public asString(): string {
+		return '!jira bulk';
+	}
+}

--- a/src/commands/BulkCommand.ts
+++ b/src/commands/BulkCommand.ts
@@ -23,7 +23,7 @@ export default class BulkCommand extends PrefixCommand {
 					const channelMessages = internalChannel.messages.cache.values();
 					for await ( const channelMessage of channelMessages ) {
 						const reaction = channelMessage.reactions.cache.get( BotConfig.request.bulkEmoji );
-						if ( reaction.users.cache.get( message.author ) ) {
+						if ( reaction.users.cache.get( message.author.id ) ) {
 							bulkMessages.add( channelMessage );
 						}
 					}
@@ -48,7 +48,7 @@ export default class BulkCommand extends PrefixCommand {
 				}
 				ticket.forEach( key => ticketKeys.push( key ) );
 				const reaction = bulkMessage.reactions.cache.get( BotConfig.request.bulkEmoji );
-				await reaction.users.remove( message.author );
+				await reaction.users.remove( message.author.id );
 			}
 		} catch ( err ) {
 			Command.logger.error( err );

--- a/src/commands/CommandRegistry.ts
+++ b/src/commands/CommandRegistry.ts
@@ -1,4 +1,5 @@
 import BugCommand from './BugCommand';
+import BulkCommand from './BulkCommand';
 import HelpCommand from './HelpCommand';
 import PingCommand from './PingCommand';
 import MooCommand from './MooCommand';
@@ -9,6 +10,7 @@ import ShutdownCommand from './ShutdownCommand';
 
 export default class CommandRegistry {
 	public static BUG_COMMAND = new BugCommand();
+	public static BULK_COMMAND = new BulkCommand();
 	public static HELP_COMMAND = new HelpCommand();
 	public static MENTION_COMMAND = new MentionCommand();
 	public static MOO_COMMAND = new MooCommand();


### PR DESCRIPTION
## Purpose
Large amounts of requests like adding versions can end up being very tedious to do Individually. With a new reaction and command, the bot will provide a Jira filter will all of the tickets from specific requests in order to use a Bulk Action.
## Approach
Workflow:
1. Add the bulk reaction to any requests
2. Type '!jira bulk'
3. The bot will send a Jira link with a filter containing all tickets in the reacted to requests
4. The bot will remove the reactions
## Future work
