### PR TITLE
Use the same logic to get original message

### DIFF
--- a/src/events/request/RequestDeleteEventHandler.ts
+++ b/src/events/request/RequestDeleteEventHandler.ts
@@ -28,7 +28,7 @@ export default class RequestDeleteEventHandler implements EventHandler<'messageD
 
 		if ( internalChannel && internalChannel instanceof TextChannel ) {
 			for ( const [, internalMessage] of internalChannel.messages.cache ) {
-				const result = RequestsUtil.getOriginIds( internalMessage );
+				const result = await RequestsUtil.getOriginIds( internalMessage );
 				if ( !result ) {
 					continue;
 				}

--- a/src/events/request/RequestEventHandler.ts
+++ b/src/events/request/RequestEventHandler.ts
@@ -107,7 +107,6 @@ export default class RequestEventHandler implements EventHandler<'message'> {
 				.setColor( 'BLUE' )
 				.setAuthor( origin.author.tag, origin.author.avatarURL() )
 				.setDescription( this.replaceTicketReferencesWithRichLinks( origin.content, regex ) )
-				.addField( 'Note', 'WIP', true )
 				.addField( 'Go To', `[Message](${ origin.url }) in ${ origin.channel }`, true )
 				.setTimestamp( new Date() );
 

--- a/src/events/request/RequestEventHandler.ts
+++ b/src/events/request/RequestEventHandler.ts
@@ -107,9 +107,8 @@ export default class RequestEventHandler implements EventHandler<'message'> {
 				.setColor( 'BLUE' )
 				.setAuthor( origin.author.tag, origin.author.avatarURL() )
 				.setDescription( this.replaceTicketReferencesWithRichLinks( origin.content, regex ) )
+				.addField( 'Note', 'WIP', true )
 				.addField( 'Go To', `[Message](${ origin.url }) in ${ origin.channel }`, true )
-				.addField( 'Channel', origin.channel.id, true )
-				.addField( 'Message', origin.id, true )
 				.setTimestamp( new Date() );
 
 			const response = BotConfig.request.prependResponseMessage == PrependResponseMessageType.Always

--- a/src/events/request/RequestReopenEventHandler.ts
+++ b/src/events/request/RequestReopenEventHandler.ts
@@ -1,4 +1,5 @@
 import { MessageEmbed, MessageReaction, TextChannel, User } from 'discord.js';
+import { RequestsUtil } from '../../util/RequestsUtil';
 import * as log4js from 'log4js';
 import BotConfig from '../../BotConfig';
 import DiscordUtil from '../../util/DiscordUtil';
@@ -20,47 +21,26 @@ export default class RequestReopenEventHandler implements EventHandler<'messageR
 	public onEvent = async ( { message }: MessageReaction, user: User ): Promise<void> => {
 		this.logger.info( `User ${ user.tag } is reopening the request message '${ message.id }'` );
 
-		const embeds = message.embeds;
-		if ( embeds.length == 0 ) {
-			try {
-				const warning = await message.channel.send( `${ message.author }, this is not a valid log message.` );
+		const requestMessage = await RequestsUtil.getOriginMessage( message );
 
-				const timeout = BotConfig.request.warningLifetime;
-				await warning.delete( { timeout } );
+		const logChannel = await DiscordUtil.getChannel( BotConfig.request.logChannel );
+		if ( logChannel && logChannel instanceof TextChannel ) {
+			const log = new MessageEmbed()
+				.setColor( 'ORANGE' )
+				.setAuthor( requestMessage.author.tag, requestMessage.author.avatarURL() )
+				.setDescription( requestMessage.content )
+				.addField( 'Channel', requestMessage.channel.toString(), true )
+				.addField( 'Message', `[Here](${ requestMessage.url })`, true )
+				.setFooter( `${ user.tag } reopened this request`, user.avatarURL() )
+				.setTimestamp( new Date() );
+
+			try {
+				await logChannel.send( log );
 			} catch ( error ) {
 				this.logger.error( error );
 			}
 		}
 
-		// Assume first embed is the log message
-		const logEmbed = embeds[0];
-		const url: string = logEmbed.fields[logEmbed.fields.length - 1].value;
-		const messageUrl = url.match( /\((.*)\)/ )[1];
-		const parts = messageUrl.split( '/' );
-
-		const originalChannel = await DiscordUtil.getChannel( parts[parts.length - 2] );
-		if ( originalChannel instanceof TextChannel ) {
-			const requestMessage = await DiscordUtil.getMessage( originalChannel, parts[parts.length - 1] );
-
-			const logChannel = await DiscordUtil.getChannel( BotConfig.request.logChannel );
-			if ( logChannel && logChannel instanceof TextChannel ) {
-				const log = new MessageEmbed()
-					.setColor( 'ORANGE' )
-					.setAuthor( requestMessage.author.tag, requestMessage.author.avatarURL() )
-					.setDescription( requestMessage.content )
-					.addField( 'Channel', requestMessage.channel.toString(), true )
-					.addField( 'Message', `[Here](${ requestMessage.url })`, true )
-					.setFooter( `${ user.tag } reopened this request`, user.avatarURL() )
-					.setTimestamp( new Date() );
-
-				try {
-					await logChannel.send( log );
-				} catch ( error ) {
-					this.logger.error( error );
-				}
-			}
-
-			await this.requestEventHandler.onEvent( requestMessage );
-		}
+		await this.requestEventHandler.onEvent( requestMessage );
 	};
 }

--- a/src/util/RequestsUtil.ts
+++ b/src/util/RequestsUtil.ts
@@ -1,25 +1,19 @@
-import { Message, TextChannel } from 'discord.js';
+import { EmbedField, Message, TextChannel } from 'discord.js';
 import * as log4js from 'log4js';
 import BotConfig from '../BotConfig';
 import DiscordUtil from './DiscordUtil';
 
+interface OriginIds {
+	channelId: string;
+	messageId: string;
+}
+
 export class RequestsUtil {
 	private static logger = log4js.getLogger( 'RequestsUtil' );
 
-	public static async getOriginIds( message: Message ): Promise<{ channelId: string; messageId: string } | undefined> {
+	private static getOriginIdsFromField( field: EmbedField ): OriginIds | undefined {
 		try {
-			const embeds = message.embeds;
-			if ( embeds.length == 0 ) {
-				const warning = await message.channel.send( `${ message.author }, this is not a valid log message.` );
-
-				const timeout = BotConfig.request.noLinkWarningLifetime;
-				await warning.delete( { timeout } );
-			}
-
-			// Assume first embed is the actual message.
-			const embed = embeds[0];
-			// Assume the last field contains the link to the original message.
-			const url: string = embed.fields[embed.fields.length - 1].value;
+			const url = field.value;
 
 			const messageUrl = url.match( /\((.*)\)/ )[1];
 			const parts = messageUrl.split( '/' );
@@ -27,11 +21,31 @@ export class RequestsUtil {
 			const channelId = parts[parts.length - 2];
 			const messageId = parts[parts.length - 1];
 
-			if ( !channelId || !messageId ) {
-				throw new Error( `Failed to get channel ID and message ID from "${ url }"` );
+			if ( channelId && messageId ) {
+				return { channelId, messageId };
+			} else {
+				return undefined;
+			}
+		} catch ( ignored ) {
+			// The field doesn't contain a valid message URL.
+			return undefined;
+		}
+	}
+
+	public static async getOriginIds( message: Message ): Promise<OriginIds | undefined> {
+		try {
+			const embeds = message.embeds;
+			if ( embeds.length == 0 ) {
+				const warning = await message.channel.send( `${ message.author }, this is not a valid log message.` );
+
+				const timeout = BotConfig.request.warningLifetime;
+				await warning.delete( { timeout } );
 			}
 
-			return { channelId, messageId };
+			// Assume first embed is the actual message.
+			const fields = embeds[0].fields;
+			// Assume either the first field or the last field contains the link to the original message.
+			return this.getOriginIdsFromField( fields[0] ) ?? this.getOriginIdsFromField( fields[fields.length - 1] );
 		} catch ( error ) {
 			this.logger.error( error );
 			return undefined;


### PR DESCRIPTION
## Purpose
Use the same logic to get original message for both log messages and internal messages.

Before this PR, the bot uses the IDs stored in plain text fields in the internal message embed to get the original message:

![image](https://user-images.githubusercontent.com/15277496/101265534-da81b180-370c-11eb-94d6-cf4fcf1c71a5.png)

After merging this PR, the bot will interprets the IDs from the message link, just like how it already does when you react a log embed to reopen the request.


## Approach

## Future work
