### PR TITLE
Fix embeds not sending if title is too long

### DIFF
--- a/src/mentions/SingleMention.ts
+++ b/src/mentions/SingleMention.ts
@@ -93,7 +93,7 @@ export class SingleMention extends Mention {
 
 		const embed = new MessageEmbed();
 		embed.setAuthor( ticketResult.fields.reporter.displayName, ticketResult.fields.reporter.avatarUrls['48x48'], 'https://bugs.mojang.com/secure/ViewProfile.jspa?name=' + encodeURIComponent( ticketResult.fields.reporter.name ) )
-			.setTitle( this.shorten( `[${ ticketResult.key }] ${ ticketResult.fields.summary }` ) )
+			.setTitle( this.ensureLength( `[${ ticketResult.key }] ${ ticketResult.fields.summary }` ) )
 			.setDescription( description.substring( 0, 2048 ) )
 			.setURL( `https://bugs.mojang.com/browse/${ ticketResult.key }` )
 			.addField( 'Status', status, !largeStatus )
@@ -151,7 +151,7 @@ export class SingleMention extends Mention {
 
 		return embed;
 	}
-	private shorten( input: string ): string {
+	private ensureLength( input: string ): string {
 		if ( input.length > 251 ) {
 			return input.substring( 0, 251 ) + '...';
 		}

--- a/src/mentions/SingleMention.ts
+++ b/src/mentions/SingleMention.ts
@@ -93,7 +93,7 @@ export class SingleMention extends Mention {
 
 		const embed = new MessageEmbed();
 		embed.setAuthor( ticketResult.fields.reporter.displayName, ticketResult.fields.reporter.avatarUrls['48x48'], 'https://bugs.mojang.com/secure/ViewProfile.jspa?name=' + encodeURIComponent( ticketResult.fields.reporter.name ) )
-			.setTitle( `[${ ticketResult.key }] ${ ticketResult.fields.summary }` )
+			.setTitle( this.shorten( `[${ ticketResult.key }] ${ ticketResult.fields.summary }` ) )
 			.setDescription( description.substring( 0, 2048 ) )
 			.setURL( `https://bugs.mojang.com/browse/${ ticketResult.key }` )
 			.addField( 'Status', status, !largeStatus )
@@ -151,4 +151,11 @@ export class SingleMention extends Mention {
 
 		return embed;
 	}
+	private shorten( input: string ): string {
+		if ( input.length > 251 ) {
+			return input.substring( 0, 251 ) + '...';
+		}
+		return input;
+	}
 }
+

--- a/src/mentions/SingleMention.ts
+++ b/src/mentions/SingleMention.ts
@@ -158,4 +158,3 @@ export class SingleMention extends Mention {
 		return input;
 	}
 }
-


### PR DESCRIPTION
## Purpose
Jira allows summaries to be up to 255 characters long. Discord has this same limit for embed titles. However, when creating an embed, MojiraBot takes not only the summary, but the ticket ID as well, and puts them in the title. This causes all embeds of tickets with summaries longer than 246 characters (with a 6-digit ID) to fail to be sent.
## Approach
If the embed title length (including the ID and the summary) exceeds 251 characters, then it will be shortened and an ellipsis will be added to the end.

I tried my best to make working code. It does work, but it may not be ideal.
## Results
<img width="533" alt="Screen Shot 2020-12-27 at 10 57 27 AM" src="https://user-images.githubusercontent.com/68699877/103174708-61203f00-4832-11eb-929a-4671f25ced82.png">
The embed is correctly sent.