### PR TITLE
Fix regex performance and security issues

### DIFF
--- a/src/events/request/RequestEventHandler.ts
+++ b/src/events/request/RequestEventHandler.ts
@@ -127,8 +127,12 @@ export default class RequestEventHandler implements EventHandler<'message'> {
 	}
 
 	private replaceTicketReferencesWithRichLinks( content: string, regex: RegExp ): string {
+		// First, escape all of the following characters with a backslash: [, ], \
+		return content.replace( /([[\]\\])/gm, '\\$1' )
+
 		// Only one of the two capture groups ($1 and $2) can catch an ID at the same time.
 		// `$1$2` is used to get the ID from either of the two groups.
-		return content.replace( /([[\]])/gm, '\\$1' ).replace( regex, '[$1$2](https://bugs.mojang.com/browse/$1$2$3)' );
+		// `$3` then is the query parameter (e.g. `?focusedCommentId=<id>`).
+			.replace( regex, '[$1$2](https://bugs.mojang.com/browse/$1$2$3)' );
 	}
 }

--- a/src/util/MarkdownUtil.ts
+++ b/src/util/MarkdownUtil.ts
@@ -50,8 +50,8 @@ export class MarkdownUtil {
 			// Remove panel
 			.replace( /\{panel:title=([^}]*)\}\n?([^]*?)\n?\{panel\}/gm, '' )
 			// Remove table header
-			.replace( /^[ \t]*((\|\|.*?)+\|\|)[ \t]*$/gm, '' )
+			.replace( /^[ \t]*((\|\|[^|]+)+\|\|)[ \t]*$/gm, '' )
 			// Remove table rows
-			.replace( /^[ \t]*((\|.*?)+\|)[ \t]*$/gm, '' );
+			.replace( /^[ \t]*((\|[^|]+)+\|)[ \t]*$/gm, '' );
 	}
 }


### PR DESCRIPTION
## Purpose
Get rid of the issues highlighted by CodeQL

## Approach
For the performance issue: Ignore pipe characters, that way the regex won't backtrack indefinitely

For the security issue: Additionally escape backslashes. This may cause some unintended side effects in cases where heavy markdown formatting is used. This should not be an issue since most requests don't include any formatting whatsoever.

## Future work
`RequestEventHandler` probably should be refactored at some point, the `regex` object is thrown around a lot. Also, it might make sense to escape _all_ markdown in `replaceTicketReferencesWithRichLinks`.