### PR TITLE
Enable auto-publish for java-fixes channel

### DIFF
--- a/config/main.yml
+++ b/config/main.yml
@@ -73,6 +73,7 @@ roleGroups:
 filterFeeds:
   - jql: project = MC AND resolved > -1m AND resolution = Fixed AND fixVersion in unreleasedVersions()
     channel: '666349583227682819'
+    publish: true
     interval: 30000
     filterFeedEmoji: '🎉'
     title: '{{num}} tickets have just been resolved as Fixed!'
@@ -83,6 +84,7 @@ versionFeeds:
   - projects:
       - MC
     channel: '666349583227682819'
+    publish: true
     interval: 30000
     scope: 5
     versionFeedEmoji: '🎉'

--- a/src/tasks/FilterFeedTask.ts
+++ b/src/tasks/FilterFeedTask.ts
@@ -77,7 +77,6 @@ export default class FilterFeedTask extends Task {
 		if ( unknownTickets.length > 0 ) {
 			try {
 				const embed = await MentionRegistry.getMention( unknownTickets ).getEmbed();
-				embed.setFooter( `#${ process.pid }` );
 
 				let message = '';
 


### PR DESCRIPTION
## Purpose
Re-enable auto-publish since we no longer seem to get repeat posts in `#java-fixes`.

## Approach
Enable the `publish` field in the config :)
Also I removed the process id from the embed as it's not needed anymore.

## Future work
Fix the version feed (see recently reported issues)