### PR TITLE
Fix long requests not being forwarded

### DIFF
--- a/src/events/request/RequestEventHandler.ts
+++ b/src/events/request/RequestEventHandler.ts
@@ -1,7 +1,6 @@
 import { Message, MessageEmbed, TextChannel } from 'discord.js';
 import * as log4js from 'log4js';
 import BotConfig, { PrependResponseMessageType } from '../../BotConfig';
-import MentionCommand from '../../commands/MentionCommand';
 import DiscordUtil from '../../util/DiscordUtil';
 import { ReactionsUtil } from '../../util/ReactionsUtil';
 import { RequestsUtil } from '../../util/RequestsUtil';
@@ -94,7 +93,7 @@ export default class RequestEventHandler implements EventHandler<'message'> {
 			const embed = new MessageEmbed()
 				.setColor( RequestsUtil.getEmbedColor() )
 				.setAuthor( origin.author.tag, origin.author.avatarURL() )
-				.setDescription( this.replaceTicketReferencesWithRichLinks( origin.content ) )
+				.setDescription( this.getRequestDescription( origin ) )
 				.addField( 'Go To', `[Message](${ origin.url }) in ${ origin.channel }`, true )
 				.setTimestamp( new Date() );
 
@@ -109,6 +108,12 @@ export default class RequestEventHandler implements EventHandler<'message'> {
 			}
 		}
 	};
+
+	private getRequestDescription( origin: Message ): string {
+		const desc = this.replaceTicketReferencesWithRichLinks( origin.content );
+		if ( desc.length > 2048 ) return `⚠ [Request too long to be posted, click here to see the request](${ origin.url })`;
+		return desc;
+	}
 
 	private replaceTicketReferencesWithRichLinks( content: string ): string {
 		const regex = new RegExp( `${ RequestsUtil.getTicketRequestRegex().source }(?<query>\\?[^\\s#]+)?(?<anchor>#\\S+)?`, 'g' );


### PR DESCRIPTION
## Purpose
Fix #172

## Approach
If the message with rich links would be too long, link to the original message instead

## Future work
N/A