### PR TITLE
Fix :mojira: emote ID in !jira help command

### DIFF
--- a/src/commands/HelpCommand.ts
+++ b/src/commands/HelpCommand.ts
@@ -8,7 +8,7 @@ export default class HelpCommand extends PrefixCommand {
 	public async run( message: Message ): Promise<boolean> {
 		try {
 			await message.channel.send(
-				`<:mojira:716988575304122370> MojiraBot help <:mojira:716988575304122370>
+				`<:mojira:821162280905211964> MojiraBot help <:mojira:821162280905211964>
 
 				This is a bot that links to a Mojira ticket when its ticket number is mentioned.
 				Currently, the following projects are supported: ${ BotConfig.projects.join( ', ' ) }


### PR DESCRIPTION
## Purpose
The :mojira: emote has recently changed IDs! It used to be 716988575304122370, but now it's 821162280905211964. Because of this, !jira help no longer properly shows the emote, and instead displays ":mojira:", which is not the intended behaviour.
## Approach
I have updated the ID.
## Future work
None.