### PR TITLE
Switch help and tips commands to embeds

### DIFF
--- a/src/commands/HelpCommand.ts
+++ b/src/commands/HelpCommand.ts
@@ -18,6 +18,7 @@ export default class HelpCommand extends PrefixCommand {
 					If you have any issues, feel free to ping violine1101.
 
 					(For help with the bug tracker, use \`!jira tips\`)`.replace( /\t/g, '' ) );
+				.setFooter( message.author.tag, message.author.avatarURL() );
 			await message.channel.send( embed );
 		} catch {
 			return false;

--- a/src/commands/HelpCommand.ts
+++ b/src/commands/HelpCommand.ts
@@ -17,7 +17,7 @@ export default class HelpCommand extends PrefixCommand {
 					It is not possible to invite this bot to other servers yet.
 					If you have any issues, feel free to ping violine1101.
 
-					(For help with the bug tracker, use \`!jira tips\`)`.replace( /\t/g, '' ) );
+					(For help with the bug tracker, use \`!jira tips\`)`.replace( /\t/g, '' ) )
 				.setFooter( message.author.tag, message.author.avatarURL() );
 			await message.channel.send( embed );
 		} catch {

--- a/src/commands/HelpCommand.ts
+++ b/src/commands/HelpCommand.ts
@@ -7,19 +7,18 @@ export default class HelpCommand extends PrefixCommand {
 
 	public async run( message: Message ): Promise<boolean> {
 		try {
-			await message.channel.send(
-				`<:mojira:821162280905211964> MojiraBot help <:mojira:821162280905211964>
+			const embed = new MessageEmbed();
+			embed.setTitle( '<:mojira:821162280905211964> **MojiraBot help** <:mojira:821162280905211964>' )
+				.setDescription( `This is a bot that links to a Mojira ticket when its ticket number is mentioned.
+					Currently, the following projects are supported: ${ BotConfig.projects.join( ', ' ) }
+					To prevent the bot from linking a ticket, preface the ticket number with an exclamation mark.
 
-				This is a bot that links to a Mojira ticket when its ticket number is mentioned.
-				Currently, the following projects are supported: ${ BotConfig.projects.join( ', ' ) }
-				To prevent the bot from linking a ticket, preface the ticket number with an exclamation mark.
-				
-				To check whether the bot is currently running, you can use \`!jira ping\`. This bot is continuously being worked on and this will receive more features in the future.
-				It is not possible to invite this bot to other servers yet.
-				If you have any issues, feel free to ping violine1101.
-				
-				(For help with the bug tracker, use !jira tips)`.replace( /\t/g, '' )
-			);
+					To check whether the bot is currently running, you can use \`!jira ping\`. This bot is continuously being worked on and this will receive more features in the future.
+					It is not possible to invite this bot to other servers yet.
+					If you have any issues, feel free to ping violine1101.
+
+					(For help with the bug tracker, use \`!jira tips\`)`.replace( /\t/g, '' ) );
+			await message.channel.send( embed );
 		} catch {
 			return false;
 		}

--- a/src/commands/HelpCommand.ts
+++ b/src/commands/HelpCommand.ts
@@ -1,4 +1,4 @@
-import { Message } from 'discord.js';
+import { Message, MessageEmbed } from 'discord.js';
 import PrefixCommand from './PrefixCommand';
 import BotConfig from '../BotConfig';
 

--- a/src/commands/TipsCommand.ts
+++ b/src/commands/TipsCommand.ts
@@ -6,16 +6,16 @@ export default class TipsCommand extends PrefixCommand {
 
 	public async run( message: Message ): Promise<boolean> {
 		try {
-			await message.channel.send(
-				`Welcome to the Mojira Discord Server! 
+			const embed = new MessageEmbed();
+			embed.setDescription( `__Welcome to the Mojira Discord Server!__
 				
 				For help with using the bug tracker, there is an article on the Minecraft website that you can read: <https://help.minecraft.net/hc/articles/360049840492>.
 				
 				How to use this server: 
 				Start by choosing which bug tracker projects you would like to be a part of in <#648479533246316555>.
 				Afterwards, you can use corresponding request channels in each project to make requests for changes to tickets on the bug tracker, like resolutions and adding affected versions. 
-				The moderators and helpers of the bug tracker will then be able to see the requests and resolve them.`.replace( /\t/g, '' )
-			);
+				The moderators and helpers of the bug tracker will then be able to see the requests and resolve them.`.replace( /\t/g, '' ) );
+			await message.channel.send( embed );
 		} catch {
 			return false;
 		}

--- a/src/commands/TipsCommand.ts
+++ b/src/commands/TipsCommand.ts
@@ -14,7 +14,7 @@ export default class TipsCommand extends PrefixCommand {
 				How to use this server: 
 				Start by choosing which bug tracker projects you would like to be a part of in <#648479533246316555>.
 				Afterwards, you can use corresponding request channels in each project to make requests for changes to tickets on the bug tracker, like resolutions and adding affected versions. 
-				The moderators and helpers of the bug tracker will then be able to see the requests and resolve them.`.replace( /\t/g, '' ) );
+				The moderators and helpers of the bug tracker will then be able to see the requests and resolve them.`.replace( /\t/g, '' ) )
 				.setFooter( message.author.tag, message.author.avatarURL() );
 			await message.channel.send( embed );
 		} catch {

--- a/src/commands/TipsCommand.ts
+++ b/src/commands/TipsCommand.ts
@@ -15,6 +15,7 @@ export default class TipsCommand extends PrefixCommand {
 				Start by choosing which bug tracker projects you would like to be a part of in <#648479533246316555>.
 				Afterwards, you can use corresponding request channels in each project to make requests for changes to tickets on the bug tracker, like resolutions and adding affected versions. 
 				The moderators and helpers of the bug tracker will then be able to see the requests and resolve them.`.replace( /\t/g, '' ) );
+				.setFooter( message.author.tag, message.author.avatarURL() );
 			await message.channel.send( embed );
 		} catch {
 			return false;

--- a/src/commands/TipsCommand.ts
+++ b/src/commands/TipsCommand.ts
@@ -1,4 +1,4 @@
-import { Message } from 'discord.js';
+import { Message, MessageEmbed } from 'discord.js';
 import PrefixCommand from './PrefixCommand';
 
 export default class TipsCommand extends PrefixCommand {


### PR DESCRIPTION
## Purpose
Currently the command text looks weird and spammy, which can be fixed by moving the command response into an embed. This also changes the formatting of the message slightly.
