### PR TITLE
Fix potential crashes caused by non-bot messages

### DIFF
--- a/src/MojiraBot.ts
+++ b/src/MojiraBot.ts
@@ -117,7 +117,7 @@ export default class MojiraBot {
 							this.logger.info( `Fetched ${ allMessages.length } messages from "${ internalChannel.name }"` );
 
 							// Resolve pending resolved requests
-							const handler = new RequestResolveEventHandler();
+							const handler = new RequestResolveEventHandler( this.client.user.id );
 							for ( const message of allMessages ) {
 								message.reactions.cache.forEach( async reaction => {
 									const users = await reaction.users.fetch();

--- a/src/events/reaction/ReactionAddEventHandler.ts
+++ b/src/events/reaction/ReactionAddEventHandler.ts
@@ -16,7 +16,7 @@ export default class ReactionAddEventHandler implements DiscordEventHandler<'mes
 	private readonly botUserId: string;
 
 	private readonly roleSelectHandler = new RoleSelectEventHandler();
-	private readonly requestResolveEventHandler = new RequestResolveEventHandler();
+	private readonly requestResolveEventHandler: RequestResolveEventHandler;
 	private readonly requestReactionRemovalEventHandler = new RequestReactionRemovalEventHandler();
 	private readonly requestReopenEventHandler: RequestReopenEventHandler;
 	private readonly mentionDeleteEventHandler = new MentionDeleteEventHandler();
@@ -25,7 +25,8 @@ export default class ReactionAddEventHandler implements DiscordEventHandler<'mes
 		this.botUserId = botUserId;
 
 		const requestEventHandler = new RequestEventHandler( internalChannels );
-		this.requestReopenEventHandler = new RequestReopenEventHandler( requestEventHandler );
+		this.requestResolveEventHandler = new RequestResolveEventHandler( botUserId );
+		this.requestReopenEventHandler = new RequestReopenEventHandler( botUserId, requestEventHandler );
 	}
 
 	// This syntax is used to ensure that `this` refers to the `ReactionAddEventHandler` object

--- a/src/events/reaction/ReactionRemoveEventHandler.ts
+++ b/src/events/reaction/ReactionRemoveEventHandler.ts
@@ -12,10 +12,11 @@ export default class ReactionRemoveEventHandler implements EventHandler<'message
 	private readonly botUserId: string;
 
 	private readonly roleRemoveHandler = new RoleRemoveEventHandler();
-	private readonly requestUnresolveEventHandler = new RequestUnresolveEventHandler();
+	private readonly requestUnresolveEventHandler: RequestUnresolveEventHandler;
 
 	constructor( botUserId: string ) {
 		this.botUserId = botUserId;
+		this.requestUnresolveEventHandler = new RequestUnresolveEventHandler( this.botUserId );
 	}
 
 	// This syntax is used to ensure that `this` refers to the `ReactionRemoveEventHandler` object

--- a/src/events/request/RequestReopenEventHandler.ts
+++ b/src/events/request/RequestReopenEventHandler.ts
@@ -11,9 +11,11 @@ export default class RequestReopenEventHandler implements EventHandler<'messageR
 
 	private logger = log4js.getLogger( 'RequestReopenEventHandler' );
 
-	private requestEventHandler: RequestEventHandler;
+	private readonly botUserId: string;
+	private readonly requestEventHandler: RequestEventHandler;
 
-	constructor( requestEventHandler: RequestEventHandler ) {
+	constructor( botUserId: string, requestEventHandler: RequestEventHandler ) {
+		this.botUserId = botUserId;
 		this.requestEventHandler = requestEventHandler;
 	}
 
@@ -22,6 +24,10 @@ export default class RequestReopenEventHandler implements EventHandler<'messageR
 		this.logger.info( `User ${ user.tag } is reopening the request message '${ message.id }'` );
 
 		message = await DiscordUtil.fetchMessage( message );
+
+		if ( message.author.id !== this.botUserId ) {
+			return;
+		}
 
 		const requestMessage = await RequestsUtil.getOriginMessage( message );
 

--- a/src/events/request/RequestResolveEventHandler.ts
+++ b/src/events/request/RequestResolveEventHandler.ts
@@ -11,9 +11,19 @@ export default class RequestResolveEventHandler implements EventHandler<'message
 
 	private logger = log4js.getLogger( 'RequestResolveEventHandler' );
 
+	private readonly botUserId: string;
+
+	constructor( botUserId: string ) {
+		this.botUserId = botUserId;
+	}
+
 	// This syntax is used to ensure that `this` refers to the `RequestResolveEventHandler` object
 	public onEvent = async ( reaction: MessageReaction, user: User ): Promise<void> => {
 		this.logger.info( `User ${ user.tag } added '${ reaction.emoji.name }' reaction to request message '${ reaction.message.id }'` );
+
+		if ( reaction.message.author.id !== this.botUserId ) {
+			return;
+		}
 
 		TaskScheduler.clearMessageTasks( reaction.message );
 		await reaction.message.edit( reaction.message.embeds[0].setColor( RequestsUtil.getEmbedColor( user ) ) );

--- a/src/events/request/RequestResolveEventHandler.ts
+++ b/src/events/request/RequestResolveEventHandler.ts
@@ -19,11 +19,12 @@ export default class RequestResolveEventHandler implements EventHandler<'message
 
 	// This syntax is used to ensure that `this` refers to the `RequestResolveEventHandler` object
 	public onEvent = async ( reaction: MessageReaction, user: User ): Promise<void> => {
-		this.logger.info( `User ${ user.tag } added '${ reaction.emoji.name }' reaction to request message '${ reaction.message.id }'` );
-
 		if ( reaction.message.author.id !== this.botUserId ) {
+			this.logger.info( `User ${ user.tag } added '${ reaction.emoji.name }' reaction to non-bot message '${ reaction.message.id }. Ignored'` );
 			return;
 		}
+
+		this.logger.info( `User ${ user.tag } added '${ reaction.emoji.name }' reaction to request message '${ reaction.message.id }'` );
 
 		TaskScheduler.clearMessageTasks( reaction.message );
 		await reaction.message.edit( reaction.message.embeds[0].setColor( RequestsUtil.getEmbedColor( user ) ) );

--- a/src/events/request/RequestUnresolveEventHandler.ts
+++ b/src/events/request/RequestUnresolveEventHandler.ts
@@ -11,11 +11,21 @@ export default class RequestUnresolveEventHandler implements EventHandler<'messa
 
 	private logger = log4js.getLogger( 'RequestUnresolveEventHandler' );
 
+	private readonly botUserId: string;
+
+	constructor( botUserId: string ) {
+		this.botUserId = botUserId;
+	}
+
 	// This syntax is used to ensure that `this` refers to the `RequestUnresolveEventHandler` object
 	public onEvent = async ( { emoji, message }: MessageReaction, user: User ): Promise<void> => {
 		this.logger.info( `User ${ user.tag } removed '${ emoji.name }' reaction from request message '${ message.id }'` );
 
 		message = await DiscordUtil.fetchMessage( message );
+
+		if ( message.author.id !== this.botUserId ) {
+			return;
+		}
 
 		await message.edit( message.embeds[0].setColor( RequestsUtil.getEmbedColor() ) );
 

--- a/src/events/request/RequestUnresolveEventHandler.ts
+++ b/src/events/request/RequestUnresolveEventHandler.ts
@@ -19,13 +19,14 @@ export default class RequestUnresolveEventHandler implements EventHandler<'messa
 
 	// This syntax is used to ensure that `this` refers to the `RequestUnresolveEventHandler` object
 	public onEvent = async ( { emoji, message }: MessageReaction, user: User ): Promise<void> => {
-		this.logger.info( `User ${ user.tag } removed '${ emoji.name }' reaction from request message '${ message.id }'` );
-
 		message = await DiscordUtil.fetchMessage( message );
 
 		if ( message.author.id !== this.botUserId ) {
+			this.logger.info( `User ${ user.tag } removed '${ emoji.name }' reaction from non-bot message '${ message.id }. Ignored'` );
 			return;
 		}
+
+		this.logger.info( `User ${ user.tag } removed '${ emoji.name }' reaction from request message '${ message.id }'` );
 
 		await message.edit( message.embeds[0].setColor( RequestsUtil.getEmbedColor() ) );
 


### PR DESCRIPTION
## Purpose
If a volunteer sends a message in an internal request channel and then adds a reaction to it, the bot crashes.

![image](https://user-images.githubusercontent.com/15277496/112866610-9893c700-907f-11eb-9a50-4e40ae5e0253.png)

Thank Jack McKalling for [his catch](https://discord.com/channels/647810384031645728/654473670198165584/826107124446003260).

## Approach

Checks if the message was sent by the bot itself before handling it.

## Future work
