### PR TITLE
Add default value for deployment in start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,2 +1,4 @@
+# Make it so the default deployment is "main"
+DEPLOYMENT=${1:-main}
 # Start a screen called "mojiradiscordbot-<deployment>" with the node process
-/usr/bin/screen -S mojiradiscordbot-$1 -d -m bash -c "NODE_ENV=$1 node bin" ; exit
+/usr/bin/screen -S mojiradiscordbot-$DEPLOYMENT -d -m bash -c "NODE_ENV=$DEPLOYMENT node bin" ; exit


### PR DESCRIPTION
## Purpose
To be able to do restart the bot via a cron job

## Approach
Add variable $DEPLOYMENT that is set to $1 when it exists, and to "main" if not

## Future work
Test this on an actual bot/server, but bash was tested with echo