### PR TITLE
Fix check for deleted message

### DIFF
--- a/src/tasks/AddProgressMessageTask.ts
+++ b/src/tasks/AddProgressMessageTask.ts
@@ -13,7 +13,7 @@ export default class AddProgressMessageTask extends MessageTask {
 	}
 
 	public async run( origin: Message ): Promise<void> {
-		// If the message has been deleted, don't do anything
+		// If the message is undefined or has been deleted, don't do anything
 		if ( origin === undefined || origin.deleted ) return;
 
 		const comment = origin.content;

--- a/src/tasks/AddProgressMessageTask.ts
+++ b/src/tasks/AddProgressMessageTask.ts
@@ -14,7 +14,7 @@ export default class AddProgressMessageTask extends MessageTask {
 
 	public async run( origin: Message ): Promise<void> {
 		// If the message has been deleted, don't do anything
-		if ( origin === undefined ) return;
+		if ( origin === undefined || origin.deleted ) return;
 
 		const comment = origin.content;
 		const date = origin.createdAt;


### PR DESCRIPTION
## Purpose
Fixing #194.
## Approach
The problem was that `origin === undefined` didn't always work correctly, and there needed to be another check to see if the message was deleted. The check was changed to `origin === undefined || origin.deleted`.