### PR TITLE
Replace internal request footer time with request's original created time

### DIFF
--- a/src/events/request/RequestEventHandler.ts
+++ b/src/events/request/RequestEventHandler.ts
@@ -95,7 +95,7 @@ export default class RequestEventHandler implements EventHandler<'message'> {
 				.setAuthor( origin.author.tag, origin.author.avatarURL() )
 				.setDescription( RequestsUtil.getRequestDescription( origin ) )
 				.addField( 'Go To', `[Message](${ origin.url }) in ${ origin.channel }`, true )
-				.setTimestamp( new Date() );
+				.setTimestamp( origin.createdAt );
 
 			const response = BotConfig.request.prependResponseMessage == PrependResponseMessageType.Always
 				? RequestsUtil.getResponseMessage( origin )


### PR DESCRIPTION
## Purpose
Close #185
## Approach
I see no reason to keep the date of the message's creation in the footer, so I changed it to the request's original creation date.