### PR TITLE
Replace MarkdownUtil.escape with discord.js escapeMarkdown function

### DIFF
--- a/src/commands/SearchCommand.ts
+++ b/src/commands/SearchCommand.ts
@@ -1,8 +1,7 @@
-import { Message, MessageEmbed } from 'discord.js';
+import { Message, MessageEmbed, Util } from 'discord.js';
 import PrefixCommand from './PrefixCommand';
 import BotConfig from '../BotConfig';
 import MojiraBot from '../MojiraBot';
-import { MarkdownUtil } from '../util/MarkdownUtil';
 
 export default class SearchCommand extends PrefixCommand {
 	public readonly aliases = ['search', 'find'];
@@ -24,7 +23,7 @@ export default class SearchCommand extends PrefixCommand {
 			} );
 
 			if ( !searchResults.issues ) {
-				embed.setTitle( `No results found for ${ MarkdownUtil.escape( plainArgs ) }` );
+				embed.setTitle( `No results found for ${ Util.escapeMarkdown( plainArgs ) }` );
 				await message.channel.send( embed );
 				return false;
 			}
@@ -33,7 +32,7 @@ export default class SearchCommand extends PrefixCommand {
 			embed.setFooter( message.author.tag, message.author.avatarURL() );
 
 			for ( const issue of searchResults.issues ) {
-				embed.addField( issue.key, `[${ MarkdownUtil.escape( issue.fields.summary ) }](https://bugs.mojang.com/browse/${ issue.key })` );
+				embed.addField( issue.key, `[${ Util.escapeMarkdown( issue.fields.summary ) }](https://bugs.mojang.com/browse/${ issue.key })` );
 			}
 
 			embed.setDescription( `[__See all results__](https://bugs.mojang.com/browse/${ searchResults.issues[0].key }?jql=${ encodeURIComponent( searchFilter ) })` );
@@ -41,7 +40,7 @@ export default class SearchCommand extends PrefixCommand {
 			await message.channel.send( embed );
 		} catch {
 			const embed = new MessageEmbed();
-			embed.setTitle( `No results found for ${ MarkdownUtil.escape( plainArgs ) }` );
+			embed.setTitle( `No results found for ${ Util.escapeMarkdown( plainArgs ) }` );
 			await message.channel.send( embed );
 			return false;
 		}

--- a/src/commands/SearchCommand.ts
+++ b/src/commands/SearchCommand.ts
@@ -23,7 +23,7 @@ export default class SearchCommand extends PrefixCommand {
 			} );
 
 			if ( !searchResults.issues ) {
-				embed.setTitle( `No results found for ${ Util.escapeMarkdown( plainArgs ) }` );
+				embed.setTitle( `No results found for "${ Util.escapeMarkdown( plainArgs ) }"` );
 				await message.channel.send( embed );
 				return false;
 			}
@@ -32,15 +32,16 @@ export default class SearchCommand extends PrefixCommand {
 			embed.setFooter( message.author.tag, message.author.avatarURL() );
 
 			for ( const issue of searchResults.issues ) {
-				embed.addField( issue.key, `[${ Util.escapeMarkdown( issue.fields.summary ) }](https://bugs.mojang.com/browse/${ issue.key })` );
+				embed.addField( issue.key, `[${ issue.fields.summary }](https://bugs.mojang.com/browse/${ issue.key })` );
 			}
 
-			embed.setDescription( `[__See all results__](https://bugs.mojang.com/browse/${ searchResults.issues[0].key }?jql=${ encodeURIComponent( searchFilter ) })` );
+			const escapedJql = encodeURIComponent( searchFilter ).replace( '(', '%28' ).replace( ')', '%29' );
+			embed.setDescription( `__[See all results](https://bugs.mojang.com/issues/?jql=${ escapedJql })__` );
 
 			await message.channel.send( embed );
 		} catch {
 			const embed = new MessageEmbed();
-			embed.setTitle( `No results found for ${ Util.escapeMarkdown( plainArgs ) }` );
+			embed.setTitle( `No results found for "${ Util.escapeMarkdown( plainArgs ) }"` );
 			await message.channel.send( embed );
 			return false;
 		}

--- a/src/mentions/MultipleMention.ts
+++ b/src/mentions/MultipleMention.ts
@@ -1,4 +1,4 @@
-import { MessageEmbed, Util } from 'discord.js';
+import { MessageEmbed } from 'discord.js';
 import MojiraBot from '../MojiraBot';
 import { Mention } from './Mention';
 
@@ -46,7 +46,7 @@ export class MultipleMention extends Mention {
 		}
 
 		for ( const issue of searchResults.issues ) {
-			embed.addField( issue.key, `[${ Util.escapeMarkdown( issue.fields.summary ) }](https://bugs.mojang.com/browse/${ issue.key })` );
+			embed.addField( issue.key, `[${ issue.fields.summary }](https://bugs.mojang.com/browse/${ issue.key })` );
 		}
 
 		if ( this.tickets.length !== searchResults.issues.length ) {

--- a/src/mentions/MultipleMention.ts
+++ b/src/mentions/MultipleMention.ts
@@ -1,6 +1,5 @@
-import { MessageEmbed } from 'discord.js';
+import { MessageEmbed, Util } from 'discord.js';
 import MojiraBot from '../MojiraBot';
-import { MarkdownUtil } from '../util/MarkdownUtil';
 import { Mention } from './Mention';
 
 export class MultipleMention extends Mention {
@@ -47,7 +46,7 @@ export class MultipleMention extends Mention {
 		}
 
 		for ( const issue of searchResults.issues ) {
-			embed.addField( issue.key, `[${ MarkdownUtil.escape( issue.fields.summary ) }](https://bugs.mojang.com/browse/${ issue.key })` );
+			embed.addField( issue.key, `[${ Util.escapeMarkdown( issue.fields.summary ) }](https://bugs.mojang.com/browse/${ issue.key })` );
 		}
 
 		if ( this.tickets.length !== searchResults.issues.length ) {

--- a/src/mentions/SingleMention.ts
+++ b/src/mentions/SingleMention.ts
@@ -1,4 +1,4 @@
-import { MessageEmbed } from 'discord.js';
+import { MessageEmbed, Util } from 'discord.js';
 import moment from 'moment';
 import MojiraBot from '../MojiraBot';
 import { MarkdownUtil } from '../util/MarkdownUtil';
@@ -83,7 +83,7 @@ export class SingleMention extends Mention {
 
 		const embed = new MessageEmbed();
 		embed.setAuthor( ticketResult.fields.reporter.displayName, ticketResult.fields.reporter.avatarUrls['48x48'], 'https://bugs.mojang.com/secure/ViewProfile.jspa?name=' + encodeURIComponent( ticketResult.fields.reporter.name ) )
-			.setTitle( this.ensureLength( `[${ ticketResult.key }] ${ MarkdownUtil.escape( ticketResult.fields.summary ) }` ) )
+			.setTitle( this.ensureLength( `[${ ticketResult.key }] ${ Util.escapeMarkdown( ticketResult.fields.summary ) }` ) )
 			.setDescription( description.substring( 0, 2048 ) )
 			.setURL( `https://bugs.mojang.com/browse/${ ticketResult.key }` )
 			.addField( 'Status', status, !largeStatus )
@@ -113,11 +113,11 @@ export class SingleMention extends Mention {
 
 		if ( ticketResult.fields.fixVersions && ticketResult.fields.fixVersions.length ) {
 			const fixVersions = ticketResult.fields.fixVersions.map( v => v.name );
-			embed.addField( 'Fix version' + ( fixVersions.length > 1 ? 's' : '' ), MarkdownUtil.escape( fixVersions.join( ', ' ) ), true );
+			embed.addField( 'Fix version' + ( fixVersions.length > 1 ? 's' : '' ), Util.escapeMarkdown( fixVersions.join( ', ' ) ), true );
 		}
 
 		if ( ticketResult.fields.assignee ) {
-			embed.addField( 'Assignee', `[${ MarkdownUtil.escape( ticketResult.fields.assignee.displayName ) }](https://bugs.mojang.com/secure/ViewProfile.jspa?name=${ encodeURIComponent( ticketResult.fields.assignee.name ) })`, true );
+			embed.addField( 'Assignee', `[${ Util.escapeMarkdown( ticketResult.fields.assignee.displayName ) }](https://bugs.mojang.com/secure/ViewProfile.jspa?name=${ encodeURIComponent( ticketResult.fields.assignee.name ) })`, true );
 		}
 
 		if ( ticketResult.fields.votes.votes ) {
@@ -134,7 +134,7 @@ export class SingleMention extends Mention {
 		}
 
 		if ( ticketResult.fields.creator.key !== ticketResult.fields.reporter.key ) {
-			embed.addField( 'Created by', `[${ MarkdownUtil.escape( ticketResult.fields.creator.displayName ) }](https://bugs.mojang.com/secure/ViewProfile.jspa?name=${ encodeURIComponent( ticketResult.fields.creator.name ) })`, true );
+			embed.addField( 'Created by', `[${ Util.escapeMarkdown( ticketResult.fields.creator.displayName ) }](https://bugs.mojang.com/secure/ViewProfile.jspa?name=${ encodeURIComponent( ticketResult.fields.creator.name ) })`, true );
 		}
 
 		embed.addField( 'Created', moment( ticketResult.fields.created ).fromNow(), true );

--- a/src/util/MarkdownUtil.ts
+++ b/src/util/MarkdownUtil.ts
@@ -54,13 +54,4 @@ export class MarkdownUtil {
 			// Remove table rows
 			.replace( /^[ \t]*((\|[^|]+)+\|)[ \t]*$/gm, '' );
 	}
-
-	/**
-	 * Escapes all meta characters supported by Discord's Markdown syntax.
-	 *
-	 * @param text The text that should be escaped
-	 */
-	public static escape( text: string ): string {
-		return text.replace( /([*_`~|\\])/g, '\\$1' );
-	}
 }


### PR DESCRIPTION
## Purpose
Fix #184
## Approach
Use discord.js's provided function `escapeMarkdown` to replace `MarkdownUtil.escape`