### PR TITLE
Limit daily requests for each user per channel

### DIFF
--- a/config/main.yml
+++ b/config/main.yml
@@ -21,6 +21,11 @@ request:
     - '683038914306506841' # bedrock-pending-requests
     - '683040112191340560' # other-pending-requests
     - '692382871578607767' # dungeons-pending-requests
+  requestLimits:
+    - 30 # Limit for # java-requests
+    - 30 # Limit for # bedrock-requests
+    - 45 # Limit for # other-requests
+    - 30 # Limit for # dungeons-requests
   testingRequestChannels:
     - '740188001052917801'
     - '807240396445843516'

--- a/config/template.yml
+++ b/config/template.yml
@@ -68,6 +68,16 @@ request:
     - <string>
     - ...
 
+  # The number of allowed requests per user per day.
+  # If the number of requests created by a single user exceeds this amount, new requests will not be forwarded to the internal channels.
+  # The length of this array MUST be the same as the length of `channels`.
+  # Setting to a negative number will remove the request limit
+  # Optional; empty by default.
+  requestLimits:
+    - <number>
+    - <number>
+    - ...
+
   # The IDs of the server's testing request channels.
   # Optional; empty by default.
   testingRequestChannels:

--- a/src/BotConfig.ts
+++ b/src/BotConfig.ts
@@ -17,6 +17,7 @@ export enum PrependResponseMessageType {
 export class RequestConfig {
 	public channels: string[];
 	public internalChannels: string[];
+	public requestLimits: number[];
 	public testingRequestChannels: string[];
 	public logChannel: string;
 
@@ -37,6 +38,7 @@ export class RequestConfig {
 	constructor() {
 		this.channels = getOrDefault( 'request.channels', [] );
 		this.internalChannels = this.channels.length ? config.get( 'request.internalChannels' ) : getOrDefault( 'request.internalChannels', [] );
+		this.requestLimits = this.channels.length ? config.get( 'request.requestLimits' ) : getOrDefault( 'request.requestLimits', [] );
 		this.testingRequestChannels = getOrDefault( 'request.testingRequestChannels', [] );
 		this.logChannel = config.get( 'request.logChannel' );
 

--- a/src/events/message/MessageEventHandler.ts
+++ b/src/events/message/MessageEventHandler.ts
@@ -16,10 +16,10 @@ export default class MessageEventHandler implements EventHandler<'message'> {
 	private readonly testingRequestEventHandler: TestingRequestEventHandler;
 	private readonly internalProgressEventHandler: InternalProgressEventHandler;
 
-	constructor( botUserId: string, internalChannels: Map<string, string> ) {
+	constructor( botUserId: string, internalChannels: Map<string, string>, requestLimits: Map<string, number> ) {
 		this.botUserId = botUserId;
 
-		this.requestEventHandler = new RequestEventHandler( internalChannels );
+		this.requestEventHandler = new RequestEventHandler( internalChannels, requestLimits );
 		this.testingRequestEventHandler = new TestingRequestEventHandler();
 		this.internalProgressEventHandler = new InternalProgressEventHandler();
 	}

--- a/src/events/reaction/ReactionAddEventHandler.ts
+++ b/src/events/reaction/ReactionAddEventHandler.ts
@@ -21,10 +21,10 @@ export default class ReactionAddEventHandler implements DiscordEventHandler<'mes
 	private readonly requestReopenEventHandler: RequestReopenEventHandler;
 	private readonly mentionDeleteEventHandler = new MentionDeleteEventHandler();
 
-	constructor( botUserId: string, internalChannels: Map<string, string> ) {
+	constructor( botUserId: string, internalChannels: Map<string, string>, requestLimits: Map<string, number> ) {
 		this.botUserId = botUserId;
 
-		const requestEventHandler = new RequestEventHandler( internalChannels );
+		const requestEventHandler = new RequestEventHandler( internalChannels, requestLimits );
 		this.requestResolveEventHandler = new RequestResolveEventHandler( botUserId );
 		this.requestReopenEventHandler = new RequestReopenEventHandler( botUserId, requestEventHandler );
 	}

--- a/src/events/request/RequestEventHandler.ts
+++ b/src/events/request/RequestEventHandler.ts
@@ -90,7 +90,7 @@ export default class RequestEventHandler implements EventHandler<'message'> {
 
 		if ( requestLimit && requestLimit >= 0 && internalChannel instanceof TextChannel ) {
 			const internalChannelUserMessages = internalChannel.messages.cache
-				.filter( message => message.embeds[0].author.name == origin.author.tag )
+				.filter( message => message.embeds.length > 0 && message.embeds[0].author.name == origin.author.tag )
 				.filter( message => new Date().valueOf() - message.embeds[0].timestamp.valueOf() <= 86400000 );
 			if ( internalChannelUserMessages.size >= requestLimit ) {
 				try {

--- a/src/events/request/RequestEventHandler.ts
+++ b/src/events/request/RequestEventHandler.ts
@@ -100,7 +100,7 @@ export default class RequestEventHandler implements EventHandler<'message'> {
 				}
 
 				try {
-					const warning = await origin.channel.send( `${ origin.author }, you currently have created more requests than the daily limit for this channel, please wait until tomorrow before creating more requests.` );
+					const warning = await origin.channel.send( `${ origin.author }, you have posted a lot of requests today that are still pending. Please wait for these requests to be resolved before posting more.` );
 
 					const timeout = BotConfig.request.warningLifetime;
 					await warning.delete( { timeout } );

--- a/src/events/request/RequestEventHandler.ts
+++ b/src/events/request/RequestEventHandler.ts
@@ -16,8 +16,14 @@ export default class RequestEventHandler implements EventHandler<'message'> {
 	 */
 	private readonly internalChannels: Map<string, string>;
 
-	constructor( internalChannels: Map<string, string> ) {
+	/**
+	 * A map from request channel IDs to request limit numbers.
+	 */
+	private readonly requestLimits: Map<string, number>;
+
+	constructor( internalChannels: Map<string, string>, requestLimits: Map<string, number> ) {
 		this.internalChannels = internalChannels;
+		this.requestLimits = requestLimits;
 	}
 
 	// This syntax is used to ensure that `this` refers to the `RequestEventHandler` object
@@ -78,6 +84,33 @@ export default class RequestEventHandler implements EventHandler<'message'> {
 			}
 		}
 
+		const requestLimit = this.requestLimits.get( origin.channel.id );
+		const internalChannelId = this.internalChannels.get( origin.channel.id );
+		const internalChannel = await DiscordUtil.getChannel( internalChannelId );
+
+		if ( requestLimit && requestLimit >= 0 && internalChannel instanceof TextChannel ) {
+			const internalChannelUserMessages = internalChannel.messages.cache
+				.filter( message => message.embeds[0].author.name == origin.author.tag )
+				.filter( message => new Date().valueOf() - message.embeds[0].timestamp.valueOf() <= 86400000 )
+			if ( internalChannelUserMessages.size >= requestLimit ) {
+				try {
+					await origin.react( BotConfig.request.invalidTicketEmoji );
+				} catch ( error ) {
+					this.logger.error( error );
+				}
+
+				try {
+					const warning = await origin.channel.send( `${ origin.author }, you currently have created more requests than the daily limit for this channel, please wait until tomorrow before creating more requests.` );
+
+					const timeout = BotConfig.request.warningLifetime;
+					await warning.delete( { timeout } );
+				} catch ( error ) {
+					this.logger.error( error );
+				}
+				return;
+			}
+		}
+
 		if ( BotConfig.request.waitingEmoji ) {
 			try {
 				await origin.react( BotConfig.request.waitingEmoji );
@@ -85,9 +118,6 @@ export default class RequestEventHandler implements EventHandler<'message'> {
 				this.logger.error( error );
 			}
 		}
-
-		const internalChannelId = this.internalChannels.get( origin.channel.id );
-		const internalChannel = await DiscordUtil.getChannel( internalChannelId );
 
 		if ( internalChannel && internalChannel instanceof TextChannel ) {
 			const embed = new MessageEmbed()

--- a/src/events/request/RequestEventHandler.ts
+++ b/src/events/request/RequestEventHandler.ts
@@ -91,7 +91,7 @@ export default class RequestEventHandler implements EventHandler<'message'> {
 		if ( requestLimit && requestLimit >= 0 && internalChannel instanceof TextChannel ) {
 			const internalChannelUserMessages = internalChannel.messages.cache
 				.filter( message => message.embeds[0].author.name == origin.author.tag )
-				.filter( message => new Date().valueOf() - message.embeds[0].timestamp.valueOf() <= 86400000 )
+				.filter( message => new Date().valueOf() - message.embeds[0].timestamp.valueOf() <= 86400000 );
 			if ( internalChannelUserMessages.size >= requestLimit ) {
 				try {
 					await origin.react( BotConfig.request.invalidTicketEmoji );

--- a/src/events/request/RequestUpdateEventHandler.ts
+++ b/src/events/request/RequestUpdateEventHandler.ts
@@ -34,6 +34,7 @@ export default class RequestUpdateEventHandler implements EventHandler<'messageU
 				if ( result.channelId === oldMessage.channel.id && result.messageId === oldMessage.id ) {
 					try {
 						const embed = internalMessage.embeds[0];
+						embed.setAuthor( oldMessage.author.tag, oldMessage.author.avatarURL() );
 						embed.setDescription( RequestsUtil.getRequestDescription( newMessage ) );
 						await internalMessage.edit( embed );
 					} catch ( error ) {


### PR DESCRIPTION
## Purpose
Close #166
## Approach
Read from internal channels to get the requests that were created less than 24 hours before, limit per channel.

Negative request limits cause no limit for the channel.
## Future work
This and the MentionDeleteEventHandler (#201) both read from the user tag, so if it is changed then it will no longer match the user, there needs to be another way around this. I added the functionality to update the user tag and icon whenever a request is updated, but that doesn't entirely fix it.