### PR TITLE
Add/remove changed suggested emojis for internal channels on restart

### DIFF
--- a/src/MojiraBot.ts
+++ b/src/MojiraBot.ts
@@ -133,7 +133,7 @@ export default class MojiraBot {
 										}
 									} else {
 										if ( message.embeds.length == 1 && bot ) {
-											const reactedEmoji = reaction.emoji.toString();
+											const reactedEmoji = reaction.emoji.name;
 											if ( !BotConfig.request.suggestedEmoji.includes( reactedEmoji ) ) {
 												try {
 													reactionsSize -= 1;


### PR DESCRIPTION
## Purpose
On restart, refresh the new or removed suggested emojis for all internal channel messages.
## Notes
This does not slow down initialization, but I'm not sure if this is the worth having a feature for. I only added this since the suggested emojis are configurable and if the bot were usable on other servers and someone changed the emojis, they'd probably expect the old messages to change as well.

This potentially implements #202 if we don't want to refresh the embeds as well.