### PR TITLE
Add date and time to request logs

### DIFF
--- a/src/events/request/RequestReopenEventHandler.ts
+++ b/src/events/request/RequestReopenEventHandler.ts
@@ -37,8 +37,9 @@ export default class RequestReopenEventHandler implements EventHandler<'messageR
 				.setColor( 'ORANGE' )
 				.setAuthor( requestMessage.author.tag, requestMessage.author.avatarURL() )
 				.setDescription( requestMessage.content )
-				.addField( 'Channel', requestMessage.channel.toString(), true )
 				.addField( 'Message', `[Here](${ requestMessage.url })`, true )
+				.addField( 'Channel', requestMessage.channel.toString(), true )
+				.addField( 'Created', requestMessage.createdAt.toUTCString(), false )
 				.setFooter( `${ user.tag } reopened this request`, user.avatarURL() )
 				.setTimestamp( new Date() );
 

--- a/src/tasks/ResolveRequestMessageTask.ts
+++ b/src/tasks/ResolveRequestMessageTask.ts
@@ -54,8 +54,9 @@ export default class ResolveRequestMessageTask extends MessageTask {
 						.setColor( 'GREEN' )
 						.setAuthor( origin.author.tag, origin.author.avatarURL() )
 						.setDescription( origin.content )
-						.addField( 'Channel', origin.channel.toString(), true )
 						.addField( 'Message', `[Here](${ origin.url })`, true )
+						.addField( 'Channel', origin.channel.toString(), true )
+						.addField( 'Created', origin.createdAt.toUTCString(), false )
 						.setFooter( `${ this.user.tag } resolved as ${ this.emoji }`, this.user.avatarURL() )
 						.setTimestamp( new Date() );
 


### PR DESCRIPTION
## Purpose
Fix #185.
## Approach
Added the timestamp, in UTC, of the original request message. This changes the order of request log messages, for both closing a request and reopening a request. Here is a sample request log message with this new format:

<img width="348" alt="Screen Shot 2021-05-16 at 3 14 17 PM" src="https://user-images.githubusercontent.com/68699877/118412750-bfc34980-b669-11eb-869d-a0786cd18202.png">
Request reopen log messages use the same format and order.

## Future work
Eventually, RequestUtil could be updated to not check the last field of an embed, because these changes reordered the request log message a bit. This probably should not be done soon, as old closed requests would not be able to be reopened once this is changed.