### PR TITLE
Fix incorrectly positioned quotes in ignored reaction log message

### DIFF
--- a/src/events/request/RequestResolveEventHandler.ts
+++ b/src/events/request/RequestResolveEventHandler.ts
@@ -20,7 +20,7 @@ export default class RequestResolveEventHandler implements EventHandler<'message
 	// This syntax is used to ensure that `this` refers to the `RequestResolveEventHandler` object
 	public onEvent = async ( reaction: MessageReaction, user: User ): Promise<void> => {
 		if ( reaction.message.author.id !== this.botUserId ) {
-			this.logger.info( `User ${ user.tag } added '${ reaction.emoji.name }' reaction to non-bot message '${ reaction.message.id }. Ignored'` );
+			this.logger.info( `User ${ user.tag } added '${ reaction.emoji.name }' reaction to non-bot message '${ reaction.message.id }'. Ignored` );
 			return;
 		}
 


### PR DESCRIPTION
## Purpose
This didn't have any effect on the bot's actions, but it kept bothering me. The end quote in the log message when a reaction is ignored was in the wrong place.