### PR TITLE
Do not create a mention embed if the message contains a certain keyword

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -10,6 +10,8 @@ quotedTicketsCauseEmbed: false
 
 forbiddenTicketPrefix: '!'
 
+forbiddenTicketText: '!nm'
+
 requiredTicketPrefix: ''
 
 embedDeletionEmoji: '🗑️'

--- a/src/BotConfig.ts
+++ b/src/BotConfig.ts
@@ -112,6 +112,7 @@ export default class BotConfig {
 	public static quotedTicketsCauseEmbed: boolean;
 	public static requiredTicketPrefix: string;
 	public static forbiddenTicketPrefix: string;
+	public static forbiddenTicketText: string;
 
 	public static embedDeletionEmoji: string;
 
@@ -138,6 +139,7 @@ export default class BotConfig {
 		this.quotedTicketsCauseEmbed = getOrDefault( 'quotedTicketsCauseEmbed', false );
 
 		this.forbiddenTicketPrefix = getOrDefault( 'forbiddenTicketPrefix', '' );
+		this.forbiddenTicketText = getOrDefault( 'forbiddenTicketText', '' );
 		this.requiredTicketPrefix = getOrDefault( 'requiredTicketPrefix', '' );
 
 		this.embedDeletionEmoji = getOrDefault( 'embedDeletionEmoji', '' );

--- a/src/commands/MentionCommand.ts
+++ b/src/commands/MentionCommand.ts
@@ -54,7 +54,7 @@ export default class MentionCommand extends Command {
 		if ( BotConfig.forbiddenTicketText ) {
 			if ( message.content.includes( BotConfig.forbiddenTicketText ) ) return false;
 		}
-		
+
 		const mention = MentionRegistry.getMention( args );
 
 		let embed: MessageEmbed;

--- a/src/commands/MentionCommand.ts
+++ b/src/commands/MentionCommand.ts
@@ -51,6 +51,10 @@ export default class MentionCommand extends Command {
 	}
 
 	public async run( message: Message, args: string[] ): Promise<boolean> {
+		if ( BotConfig.forbiddenTicketText ) {
+			if ( message.content.includes( BotConfig.forbiddenTicketText ) ) return false;
+		}
+		
 		const mention = MentionRegistry.getMention( args );
 
 		let embed: MessageEmbed;


### PR DESCRIPTION
## Purpose
Adds #14.
## Approach
If `forbiddenTicketText` (default is `!nm` [no mention]) is set in `default.yml`, MojiraBot won't create a ticket embed if the message contains the forbidden text.