### PR TITLE
Fix pending request embed update

### DIFF
--- a/src/events/request/RequestResolveEventHandler.ts
+++ b/src/events/request/RequestResolveEventHandler.ts
@@ -27,14 +27,16 @@ export default class RequestResolveEventHandler implements EventHandler<'message
 		this.logger.info( `User ${ user.tag } added '${ reaction.emoji.name }' reaction to request message '${ reaction.message.id }'` );
 
 		TaskScheduler.clearMessageTasks( reaction.message );
-		await reaction.message.edit( reaction.message.embeds[0].setColor( RequestsUtil.getEmbedColor( user ) ) );
+
+		const embed = reaction.message.embeds[0].setColor( RequestsUtil.getEmbedColor( user ) );
+		await reaction.message.edit( embed );
 
 		if ( BotConfig.request.prependResponseMessage == PrependResponseMessageType.WhenResolved
 			&& BotConfig.request.ignorePrependResponseMessageEmoji !== reaction.emoji.name ) {
 			const origin = await RequestsUtil.getOriginMessage( reaction.message );
 			if ( origin ) {
 				try {
-					await reaction.message.edit( RequestsUtil.getResponseMessage( origin ) );
+					await reaction.message.edit( RequestsUtil.getResponseMessage( origin ), embed );
 				} catch ( error ) {
 					this.logger.error( error );
 				}

--- a/src/events/request/RequestUnresolveEventHandler.ts
+++ b/src/events/request/RequestUnresolveEventHandler.ts
@@ -1,6 +1,6 @@
 import { MessageReaction, User } from 'discord.js';
 import * as log4js from 'log4js';
-import BotConfig, { PrependResponseMessageType } from '../../BotConfig';
+import BotConfig from '../../BotConfig';
 import TaskScheduler from '../../tasks/TaskScheduler';
 import DiscordUtil from '../../util/DiscordUtil';
 import { RequestsUtil } from '../../util/RequestsUtil';
@@ -28,15 +28,7 @@ export default class RequestUnresolveEventHandler implements EventHandler<'messa
 
 		this.logger.info( `User ${ user.tag } removed '${ emoji.name }' reaction from request message '${ message.id }'` );
 
-		await message.edit( message.embeds[0].setColor( RequestsUtil.getEmbedColor() ) );
-
-		if ( BotConfig.request.prependResponseMessage == PrependResponseMessageType.WhenResolved ) {
-			try {
-				await message.edit( '' );
-			} catch ( error ) {
-				this.logger.error( error );
-			}
-		}
+		await message.edit( '', message.embeds[0].setColor( RequestsUtil.getEmbedColor() ) );
 
 		if ( message.reactions.cache.size <= BotConfig.request.suggestedEmoji.length ) {
 			this.logger.info( `Cleared message task for request message '${ message.id }'` );


### PR DESCRIPTION
## Purpose
Previously, when resolving a request with anything other than the green checkmark, or when unresolving a request the bot would just remove the embed of a pending request message, causing subsequent issues.

## Approach
Always make sure that when editing we pass the embed as well

## Future work
Probably clean up this a little bit. Currently the message is always edited twice which is not optimal but it works.