### PR TITLE
Force request reopening

### DIFF
--- a/src/events/request/RequestEventHandler.ts
+++ b/src/events/request/RequestEventHandler.ts
@@ -27,7 +27,7 @@ export default class RequestEventHandler implements EventHandler<'message'> {
 	}
 
 	// This syntax is used to ensure that `this` refers to the `RequestEventHandler` object
-	public onEvent = async ( origin: Message ): Promise<void> => {
+	public onEvent = async ( origin: Message, forced?: boolean ): Promise<void> => {
 		// we need this because this method gets invoked directly on bot startup instead of via the general MessageEventHandler
 		if ( origin.type !== 'DEFAULT' ) {
 			return;
@@ -88,7 +88,7 @@ export default class RequestEventHandler implements EventHandler<'message'> {
 		const internalChannelId = this.internalChannels.get( origin.channel.id );
 		const internalChannel = await DiscordUtil.getChannel( internalChannelId );
 
-		if ( requestLimit && requestLimit >= 0 && internalChannel instanceof TextChannel ) {
+		if ( !forced && requestLimit && requestLimit >= 0 && internalChannel instanceof TextChannel ) {
 			const internalChannelUserMessages = internalChannel.messages.cache
 				.filter( message => message.embeds.length > 0 && message.embeds[0].author?.name === origin.author.tag )
 				.filter( message => message.embeds[0].timestamp !== null && new Date().valueOf() - message.embeds[0].timestamp.valueOf() <= 86400000 );

--- a/src/events/request/RequestReopenEventHandler.ts
+++ b/src/events/request/RequestReopenEventHandler.ts
@@ -54,6 +54,6 @@ export default class RequestReopenEventHandler implements EventHandler<'messageR
 			}
 		}
 
-		await this.requestEventHandler.onEvent( requestMessage );
+		await this.requestEventHandler.onEvent( requestMessage, true );
 	};
 }


### PR DESCRIPTION
## Purpose
Force requests to be reopened, disregarding number of requests by a user within the past 24 hours, when a volunteer reopens a request.
I think this should work.
## Approach
Add an optional `forced` parameter to the request event handler, which is only set to true when it is run from the request reopen event handler. If it is forced, the 24 hour check is skipped.
