### PR TITLE
Remove quotes from regular expressions in SearchCommand

### DIFF
--- a/src/commands/SearchCommand.ts
+++ b/src/commands/SearchCommand.ts
@@ -35,7 +35,7 @@ export default class SearchCommand extends PrefixCommand {
 				embed.addField( issue.key, `[${ issue.fields.summary }](https://bugs.mojang.com/browse/${ issue.key })` );
 			}
 
-			const escapedJql = encodeURIComponent( searchFilter ).replace( '/(/g', '%28' ).replace( '/)/g', '%29' );
+			const escapedJql = encodeURIComponent( searchFilter ).replace( /\(/g, '%28' ).replace( /\)/g, '%29' );
 			embed.setDescription( `__[See all results](https://bugs.mojang.com/issues/?jql=${ escapedJql })__` );
 
 			await message.channel.send( embed );


### PR DESCRIPTION
## Purpose
This should fix the problem mentioned in #249 (not tested though).
## Approach
This removes the quotes from the regular expressions in `SearchCommand`, as regular expressions inside quotes are interpreted as strings and not as regular expressions.