### PR TITLE
Make CI run on `pull_request`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,24 +1,25 @@
 name: Test
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    # Only run on PRs if the source branch is on someone else's repo
+    if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}
     strategy:
       matrix:
         node-version: [16.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
 
-    - uses: actions/cache@v1
+    - uses: actions/cache@v3
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
## Purpose
Fixes #254
## Approach
The `test.yml` had only:
```yml
name: Test
on: [push]
```
and it needs the `pull_request` check, so:
```yml
name: Test
on: [push, pull_request]
```
I've also included an if statement to skip the job on `pull_request` *unless* the source branch is on a fork.
## Future work
Haven't been able to test, since to test it we'd have to merge this into `master`, fork the repo, and then make some change and make a PR. But not really sure if that's needed or not.