### PR TITLE
Add support for pomelos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "mojira-discord-bot",
       "license": "GPL-3.0",
       "dependencies": {
         "@discordjs/rest": "^0.4.1",

--- a/src/commands/MentionCommand.ts
+++ b/src/commands/MentionCommand.ts
@@ -71,8 +71,13 @@ export default class MentionCommand extends Command {
 		}
 
 		if ( embed === undefined ) return false;
-
-		embed.setFooter( { text: message.author.tag, iconURL: message.author.avatarURL() ?? undefined } )
+		let messageAuthorNormalizedTag: string;
+		if ( message.author.discriminator === '0' ) {
+			messageAuthorNormalizedTag = message.author.username;
+		} else {
+			messageAuthorNormalizedTag = message.author.tag;
+		}
+		embed.setFooter( { text: messageAuthorNormalizedTag, iconURL: message.author.avatarURL() ?? undefined } )
 			.setTimestamp( message.createdAt );
 
 		try {


### PR DESCRIPTION
## Purpose
`#0` looks silly and is inaccurate

## Approach
just check the discrim

## Future work
When discord.js fixes the `tag` field, this could be removed
