### PR TITLE
Fix embed generation failing with double header

### DIFF
--- a/src/mentions/SingleMention.ts
+++ b/src/mentions/SingleMention.ts
@@ -88,7 +88,7 @@ export class SingleMention extends Mention {
 		const embed = new EmbedBuilder();
 
 		embed.setTitle( this.ensureLength( `[${ ticketResult.key }] ${ escapeMarkdown( ticketResult.fields.summary ) }` ) )
-			.setDescription( description.substring( 0, 2048 ) )
+			.setDescription( description.substring( 0, 2048 ) || null )
 			.setURL( `https://bugs.mojang.com/browse/${ ticketResult.key }` )
 			.setColor( 'Red' );
 


### PR DESCRIPTION
## Purpose
An issue with at least two header lines at the start of its description fails to produce an embed. For example, the following description would result in an error message when requesting its embed:
```
### The bug
#### Part 1
...
```
This is because MojiraBot removes the first header, and takes everything between where it was and the next header. With a double header, there is no content to consider, and an empty description is used as the embed's description. Discord.js does not accept an empty string for this value for some reason.
## Approach
If the description is the empty string, replace it with `null`, as this is accepted.