### PR TITLE
Fix version feeds

### DIFF
--- a/config/main.yml
+++ b/config/main.yml
@@ -113,7 +113,7 @@ filterFeeds:
   #   titleSingle: This ticket has just been marked as fixed!
   #   cached: true
 
-versionFeeds: []
+versionFeeds:
     #java-fixes
   # - projects:
   #     - MC
@@ -139,21 +139,25 @@ versionFeeds: []
   #     - unreleased
 
     #version-feed
-  # - projects:
-  #     - BDS
-  #     - MC
-  #     - MCD
-  #     - MCL
-  #     - MCPE
-  #     - REALMS
-  #   channel: '741600360619049000'
-  #   publish: true
-  #   interval: 10000
-  #   scope: 5
-  #   actions:
-  #     - created
-  #     - archived
-  #     - unarchived
-  #     - released
-  #     - unreleased
-  #     - renamed
+    - projects:
+      - name: BDS
+        id: 11700
+      - name: MC
+        id: 10400
+      - name: MCL
+        id: 11101
+      - name: MCPE
+        id: 10200
+      - name: REALMS
+        id: 11402
+      channel: "741600360619049000"
+      publish: false
+      interval: 10000
+      scope: 5
+      actions:
+        - created
+        - archived
+        - unarchived
+        - released
+        - unreleased
+        - renamed

--- a/src/BotConfig.ts
+++ b/src/BotConfig.ts
@@ -95,8 +95,13 @@ export interface FilterFeedConfig {
 	cached?: boolean;
 }
 
+export interface VersionConfig {
+	name: string;
+	id: number;
+}
+
 export interface VersionFeedConfig {
-	projects: string[];
+	projects: VersionConfig[];
 	channel: Snowflake;
 	interval: number;
 	versionFeedEmoji: string | Snowflake;


### PR DESCRIPTION
## Purpose
Version feeds have been failing for maybe two years now. The cause of the issue seems to be the fact that project IDs were being returned in the version list rather than project keys.
## Approach
The config file was adapted to accept a key-ID pair list for each version feed. When fetching a list of versions, keys are used to search for a project's version, while IDs are used to convert returned versions' projects into embed fields.
## Future work
These changes only enable the version-feed channel.