### PR TITLE
Remove MCD and MCL request channels and roles, as well as pronoun roles

### DIFF
--- a/config/main.yml
+++ b/config/main.yml
@@ -18,20 +18,14 @@ request:
     - '648555618994618378' # java-requests
     - '648555751438155776' # bedrock-requests
     - '651161365091844116' # other-requests
-    - '692382286103969843' # dungeons-requests
-    - '1097590072351662140' # legends-requests
   internalChannels:
     - '683038862024638474' # java-pending-requests
     - '683038914306506841' # bedrock-pending-requests
     - '683040112191340560' # other-pending-requests
-    - '692382871578607767' # dungeons-pending-requests
-    - '1097592319462604820' # legends-pending-requests
   requestLimits:
     - 30 # Limit for # java-requests
     - 30 # Limit for # bedrock-requests
     - 45 # Limit for # other-requests
-    - 30 # Limit for # dungeons-requests
-    - 30 # Limit for # legends-requests
   testingRequestChannels:
     - '740188001052917801'
     - '807240396445843516'
@@ -50,23 +44,19 @@ roleGroups:
         desc: _Windows, macOS and Linux_
         emoji: '648525192414494730'
       - id: '648536590481752074'
-        title: Bedrock Edition (MCPE)
+        title: Bedrock Edition (BDS, MCPE)
         desc: |-
           _Android, iOS, Windows 10/11, ChromeOS,
           Xbox, Nintendo Switch, Playstation, and Amazon Fire_
         emoji: '648474430158405642'
-      - id: '692398773762261023'
-        title: Minecraft Dungeons (MCD)
-        desc: _Dungeon crawler spin-off_
-        emoji: '692399397232836758'
-      - id: '1097589181154336789'
-        title: Minecraft Legends (MCLG)
-        desc: _Action-strategy spin-off_
-        emoji: '1093281397843689563'
       - id: '648536618113826847'
-        title: Other projects
-        desc: (BDS, MCL, REALMS, WEB)
+        title: Other projects (MCL, REALMS, WEB)
+        desc: _Projects concerning both Java and Bedrock_
         emoji: '648521149390520320'
+      - id: '1097589181154336789'
+        title: Archived projects (MCCE, MCE, MCD, MCLG)
+        desc: _Read-only access to all archived channels_
+        emoji: '692399397232836758'
   - prompt: Please select the pronoun(s) that you'd like to go by.
     desc: This is not mandatory, but we encourage people to use the appropriate pronouns when referring to each other.
     color: Blue

--- a/config/main.yml
+++ b/config/main.yml
@@ -57,26 +57,6 @@ roleGroups:
         title: Archived projects (MCCE, MCE, MCD, MCLG)
         desc: _Read-only access to all archived channels_
         emoji: '692399397232836758'
-  - prompt: Please select the pronoun(s) that you'd like to go by.
-    desc: This is not mandatory, but we encourage people to use the appropriate pronouns when referring to each other.
-    color: Blue
-    channel: '648479533246316555'
-    message: '753757208575082556'
-    radio: false # Some people might go by multiple pronouns? So why I implemented the radio feature 😅
-    roles:
-      - id: '753741802829381765'
-        title: He/Him
-        emoji: '🇭'
-      - id: '753741949474832434'
-        title: She/Her
-        emoji: '🇸'
-      - id: '753742065971757167'
-        title: They/Them
-        emoji: '🇹'
-      - id: '753745759148572801'
-        title: Other Pronoun
-        desc: (please indicate in your nickname)
-        emoji: '🇴'
 
 filterFeeds:
     #java-triage


### PR DESCRIPTION
## Purpose
* MCD and MCL have been archived; finally remove the request channel linkage with MojiraBot to be able to properly archive these channels.
* Pronoun roles are no longer necessary since Discord has implemented a pronoun field in user profiles

## Approach
* Remove MCD and MCL request channels from config
* Remove MCD and MCL roles from role selection
* Add archived projects role for accessing archived channels, rather than bundling it with other projects