### PR TITLE
Use 'bugs-legacy' api route

### DIFF
--- a/src/BotConfig.ts
+++ b/src/BotConfig.ts
@@ -194,7 +194,7 @@ export default class BotConfig {
 	public static jiraLogin(): void {
 		// TODO: integrate newErrorHandling from Jira.js
 		MojiraBot.jira = new JiraClient( {
-			host: 'https://bugs.mojang.com',
+			host: 'https://bugs-legacy.mojang.com',
 			telemetry: false,
 			authentication: this.jiraPat === undefined ? undefined : {
 				personalAccessToken: this.jiraPat,


### PR DESCRIPTION
## Purpose

As mojira is transitioning to a new format, and their current route is down, use the legacy route which is still working for now till the new API becomes public.

## Approach

Modified src/BotConfig.ts 'host' to be 'bugs-legacy.mojang.com'

## Future work

?