### PR TITLE
Allow the bot to work with Jira Cloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 .vscode/*
 .history
 **/.DS_Store
+.idea/
 
 **/*.log
 settings.json

--- a/config/local.template.yml
+++ b/config/local.template.yml
@@ -1,6 +1,6 @@
 # 1. Copy this file
 # 2. Rename the copy to `local.yml`
-# 3. Change the bot token, and your Jira personal access token if desired, and save the file
+# 3. Change the bot token, and your Jira email+personal access token if desired, and save the file
 #
 # You can add more configs if you want to.
 #
@@ -11,4 +11,5 @@
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 token: <your bot token>
+jiraUser: <your jira email>
 jiraPat: <your personal access token>

--- a/config/template.yml
+++ b/config/template.yml
@@ -11,8 +11,9 @@ logDirectory: <string | false>
 # Your bot token used to log in to Discord with the bot.
 token: <string>
 
-# Your Jira personal access token.
+# Your Jira E-Mail and personal access token.
 # Optional; if not assigned a value, the bot will not attempt to log into Jira.
+jiraUser: <string>
 jiraPat: <string>
 
 # A list of user IDs for owner only commands.

--- a/src/BotConfig.ts
+++ b/src/BotConfig.ts
@@ -116,6 +116,7 @@ export default class BotConfig {
 
 	private static token: string;
 	private static jiraPat?: string;
+	private static jiraUser?: string;
 
 	public static owners: Snowflake[];
 
@@ -149,6 +150,7 @@ export default class BotConfig {
 		this.logDirectory = getOrDefault( 'logDirectory', false );
 
 		this.token = config.get( 'token' );
+		this.jiraUser = getOrDefault( 'jiraUser', undefined );
 		this.jiraPat = getOrDefault( 'jiraPat', undefined );
 
 		this.owners = getOrDefault( 'owners', [] );
@@ -194,10 +196,12 @@ export default class BotConfig {
 	public static jiraLogin(): void {
 		// TODO: integrate newErrorHandling from Jira.js
 		MojiraBot.jira = new JiraClient( {
-			host: 'https://bugs.mojang.com',
-			telemetry: false,
-			authentication: this.jiraPat === undefined ? undefined : {
-				personalAccessToken: this.jiraPat,
+			host: 'https://mojira.atlassian.net',
+			authentication: this.jiraPat === undefined || this.jiraUser === undefined ? undefined : {
+				basic: {
+					email: this.jiraUser,
+					apiToken: this.jiraPat,
+				},
 			},
 		} );
 	}

--- a/src/commands/SearchCommand.ts
+++ b/src/commands/SearchCommand.ts
@@ -21,7 +21,7 @@ export default class SearchCommand extends SlashCommand {
 
 		try {
 			const embed = new EmbedBuilder();
-			const searchFilter = `text ~ "${ plainArgs }" AND project in (${ BotConfig.projects.join( ', ' ) })`;
+			const searchFilter = `(description ~ "${ plainArgs }" OR summary ~ "${ plainArgs }") AND project in (${ BotConfig.projects.join( ', ' ) })`;
 			const searchResults = await MojiraBot.jira.issueSearch.searchForIssuesUsingJql( {
 				jql: searchFilter,
 				maxResults: BotConfig.maxSearchResults,

--- a/src/tasks/VersionFeedTask.ts
+++ b/src/tasks/VersionFeedTask.ts
@@ -13,7 +13,7 @@ interface JiraVersion {
 	archived: boolean;
 	released: boolean;
 	releaseDate?: string;
-	projectId: number;
+	projectId: number | string;
 }
 
 function versionConv( version: Version ): JiraVersion | undefined {


### PR DESCRIPTION
- Cloud does not support PAT-only auth and needs the Email too
- The `projectId` type change is just to make for an easier jira.js library update in case that's needed. The type in newer versions is string or number

The user and pat need to be changed in the config, so does the bugnet user in a `filterFeeds` JQL query