### PR TITLE
Update request url from internal view

### DIFF
--- a/src/util/RequestsUtil.ts
+++ b/src/util/RequestsUtil.ts
@@ -149,6 +149,6 @@ export class RequestsUtil {
 
 		// Escape all of the following characters with a backslash: [, ], \
 		return content.replace( /([[\]\\])/gm, '\\$1' )
-			.replace( regex, '[$<ticketid>$<anchor>](https://bugs.mojang.com/browse/$<ticketid>$<query>$<anchor>)' );
+			.replace( regex, '[$<ticketid>$<anchor>](https://mojira.atlassian.net/browse/$<ticketid>$<query>$<anchor>)' );
 	}
 }


### PR DESCRIPTION
The regex a bit above needs fixing, but as is it'll also catch report ids in the new report.bugs domain so it still works