### PR TITLE
Update MentionDeleteEventHandler to reflect Discord's new username format

### DIFF
--- a/src/events/mention/MentionDeleteEventHandler.ts
+++ b/src/events/mention/MentionDeleteEventHandler.ts
@@ -13,7 +13,7 @@ export default class MentionDeleteEventHandler implements EventHandler<'messageR
 		const footer = message.embeds[0]?.footer?.text;
 		if ( footer === undefined ) return;
 
-		const userTag = footer.match( /.{3,32}#[0-9]{4}/ );
+		const userTag = footer.match( /[a-z0-9_.]{2,32}/ );
 
 		if ( userTag !== null && user.tag === userTag[0] ) {
 			try {


### PR DESCRIPTION
## Purpose
Update MentionDeleteEventHandler to reflect Discord's new username format, as it currently looks for legacy _usernames#1234_ that have been phased out
## Approach
New regex pattern that follows Discord's new username format
## Future work
