### PR TITLE
Reject unofficial bug tracker links

### DIFF
--- a/src/events/request/RequestEventHandler.ts
+++ b/src/events/request/RequestEventHandler.ts
@@ -47,6 +47,29 @@ export default class RequestEventHandler implements EventHandler<'messageCreate'
 			this.logger.error( error );
 		}
 
+		// Reject requests that link to unofficial bug tracker mirrors.
+		// Only bugs.mojang.com is the authoritative source; sites like mojira.dev
+		// are third-party mirrors and should not be used for requests.
+		if ( RequestsUtil.containsUnofficialBugTrackerLink( origin.content ) ) {
+			try {
+				await origin.react( BotConfig.request.invalidTicketEmoji );
+			} catch ( error ) {
+				this.logger.error( error );
+			}
+
+			try {
+				const warning = await origin.channel.send(
+					`${ origin.author }, your request (<${ origin.url }>) contains a link to an unofficial bug tracker mirror. ` +
+					`Please only link to tickets on the official Mojang bug tracker: <https://bugs.mojang.com>.`
+				);
+				await DiscordUtil.deleteWithDelay( warning, BotConfig.request.warningLifetime );
+			} catch ( error ) {
+				this.logger.error( error );
+			}
+
+			return;
+		}
+
 		const tickets = RequestsUtil.getTicketIdsFromString( origin.content );
 
 		if ( BotConfig.request.noLinkEmoji && !tickets.length ) {

--- a/src/util/RequestsUtil.ts
+++ b/src/util/RequestsUtil.ts
@@ -96,6 +96,23 @@ export class RequestsUtil {
 
 
 	/**
+	 * Checks whether the message content contains a URL pointing to an unofficial
+	 * bug tracker mirror (like mojira.dev) rather than the official bugs.mojang.com.
+	 *
+	 * The regex matches any http(s) URL whose host is NOT bugs.mojang.com (or the
+	 * report. subdomain) but whose path still contains something that looks like a
+	 * Jira ticket ID.  We intentionally keep the pattern loose on the URL side so
+	 * that novel mirror domains are caught automatically.
+	 */
+	public static containsUnofficialBugTrackerLink( content: string ): boolean {
+		const unofficialLinkRegex = new RegExp(
+			`https?://(?!(?:report\\.)?bugs\\.mojang\\.com(?:/|$))[^\\s<>]*\\b${ MentionCommand.ticketPattern }`,
+			'i'
+		);
+		return unofficialLinkRegex.test( content );
+	}
+
+	/**
 	 * This extracts a ticket ID from either a link or a standalone ticket ID.
 	 * E.g. this matches the "MC-1234" in https://bugs.mojang.browse/MC-1234 or in "This is some crazy bug:MC-1234".
 	 * @returns A NEW regex object every time. You have to store it as a variable if you use `exec` on it, otherwise you will encounter infinite loops.


### PR DESCRIPTION
## Purpose
Rejects requests that contain links to unofficial bug tracker mirrors (such as mojira-viewer.jacobsjo.eu, mojira.dev) instead of the official bugs.mojang.com. This prevents users from referencing third-party mirrors.

## Approach
Added a static method `containsUnofficialBugTrackerLink()` in `RequestsUtil` that uses a regex to detect any third-party URL. In `RequestEventHandler`, this check is run before processing a request, if an unofficial link is detected, the bot reacts with the invalid ticket emoji and sends a warning message directing the user to bugs.mojang.com, then returns early.


## Future work
N/A